### PR TITLE
Remove @ApiQuery from controllers to fix swagger docs

### DIFF
--- a/src/sfdc-reports/sfdc-reports.controller.ts
+++ b/src/sfdc-reports/sfdc-reports.controller.ts
@@ -3,7 +3,6 @@ import { Controller, Get, Query, UseGuards } from "@nestjs/common";
 import {
   ApiBearerAuth,
   ApiOperation,
-  ApiQuery,
   ApiResponse,
   ApiTags,
 } from "@nestjs/swagger";
@@ -34,9 +33,6 @@ export class SfdcReportsController {
     summary: "SFDC Payments report",
     description: "",
   })
-  @ApiQuery({
-    type: PaymentsReportQueryDto,
-  })
   @ApiResponse({
     status: 200,
     description: "Export successfully.",
@@ -54,9 +50,6 @@ export class SfdcReportsController {
   @ApiOperation({
     summary: "Report of BA to fee / member payment",
     description: "",
-  })
-  @ApiQuery({
-    type: BaFeesReportQueryDto,
   })
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
In the new swagger version, it's enough to pass a DTO for the @Query parameter. Adding a @ApiQuery will duplicate the swagger params. Fixed by removing @ApiQuery