### PR TITLE
fix(PM-1127): query issue with topgear reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ workflows:
           branches:
             only:
               - develop
+              - pm-1127_1
             
     # Production builds are exectuted only on tagged commits to the
     # master branch.

--- a/src/reports/topgear/topgear-reports.service.ts
+++ b/src/reports/topgear/topgear-reports.service.ts
@@ -7,6 +7,7 @@ import {
   defaultEndDate,
 } from "../../common/validation.util";
 import { ChallengeStatsByUserDto } from "./dtos/challenge-stats-by-user.dto";
+import { subDays } from "date-fns";
 
 @Injectable()
 export class TopgearReportsService {
@@ -24,7 +25,7 @@ export class TopgearReportsService {
     startDate?: string;
     endDate?: string;
   }): Promise<ChallengeStatsByUserDto[]> {
-    const startDate = opts.startDate ? new Date(opts.startDate) : new Date(0);
+    const startDate = opts.startDate ? new Date(opts.startDate) : subDays(new Date(), 7);
     const endDate = opts.endDate ? new Date(opts.endDate) : new Date();
 
     if (startDate > endDate) {


### PR DESCRIPTION
## What's in this PR?

- query issue with topgear reports
- If no start and end dates are provided, then get just last 7 days data, this ways server timeouts can be avoided.

