### PR TITLE
PM-4800: align engagement report country with profile

### DIFF
--- a/sql/reports/topcoder/engagement-data-members.sql
+++ b/sql/reports/topcoder/engagement-data-members.sql
@@ -4,8 +4,15 @@ SELECT
   NULLIF(BTRIM(m."firstName"), '') AS first_name,
   NULLIF(BTRIM(m."lastName"), '') AS last_name,
   NULLIF(BTRIM(m.email), '') AS email,
-  COALESCE(NULLIF(BTRIM(c.country_name), ''), NULLIF(BTRIM(m.country), ''))
-    AS country,
+  COALESCE(
+    home_code.name,
+    home_id.name,
+    comp_code.name,
+    comp_id.name,
+    NULLIF(BTRIM(m."homeCountryCode"), ''),
+    NULLIF(BTRIM(m."competitionCountryCode"), ''),
+    NULLIF(BTRIM(m.country), '')
+  ) AS country,
   preferred_address.street_addr_1,
   preferred_address.street_addr_2,
   preferred_address.city,
@@ -13,8 +20,14 @@ SELECT
   preferred_address.zip,
   preferred_phone.phone_number
 FROM members.member m
-LEFT JOIN identity.country c
-  ON c.iso_alpha3_code = m."competitionCountryCode"
+LEFT JOIN lookups."Country" AS home_code
+  ON UPPER(home_code."countryCode") = UPPER(m."homeCountryCode")
+LEFT JOIN lookups."Country" AS home_id
+  ON UPPER(home_id.id) = UPPER(m."homeCountryCode")
+LEFT JOIN lookups."Country" AS comp_code
+  ON UPPER(comp_code."countryCode") = UPPER(m."competitionCountryCode")
+LEFT JOIN lookups."Country" AS comp_id
+  ON UPPER(comp_id.id) = UPPER(m."competitionCountryCode")
 LEFT JOIN LATERAL (
   SELECT
     NULLIF(BTRIM(a."streetAddr1"), '') AS street_addr_1,

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -645,7 +645,8 @@ export class TopcoderReportsService implements OnModuleDestroy {
    *
    * The base member list comes from the engagements database, while member
    * profile/contact fields and project names are resolved directly from the
-   * main reports database so the export stays DB-only.
+   * main reports database so the export stays DB-only. Country resolution
+   * follows the same home-country-first fallback order used by the profile UI.
    *
    * @returns One row per member with the engagement experience summary fields.
    * @throws Error when the engagements database URL is not configured.

--- a/src/reports/topcoder/topcoder-reports.sql.spec.ts
+++ b/src/reports/topcoder/topcoder-reports.sql.spec.ts
@@ -1,0 +1,13 @@
+import { SqlLoaderService } from "src/common/sql-loader.service";
+
+describe("Topcoder report SQL", () => {
+  const sqlLoader = new SqlLoaderService();
+
+  it("uses profile-style country precedence for engagement data members", () => {
+    const sql = sqlLoader.load("reports/topcoder/engagement-data-members.sql");
+
+    expect(sql).toMatch(
+      /COALESCE\(\s*home_code\.name,\s*home_id\.name,\s*comp_code\.name,\s*comp_id\.name,\s*NULLIF\(BTRIM\(m\."homeCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\."competitionCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\.country\), ''\)\s*\)\s+AS country/,
+    );
+  });
+});


### PR DESCRIPTION
What was broken
QA found that the Engagement Data report could still show the wrong country or null for some members even after the original PM-4800 report was added. The remaining examples were members whose Profile app location showed a home-country value like Japan or Sri Lanka while the export showed Aruba or null.

Root cause
The engagement member enrichment SQL was resolving country from competition-country data and the denormalized member country field instead of following the Profile app's home-country-first fallback order.

What was changed
Updated the engagement member enrichment SQL to resolve country names through the lookups country table with homeCountryCode first, then competitionCountryCode, then the stored member country fallback.
Updated the engagement report service documentation to reflect the profile-aligned country precedence.

Any added/updated tests
Added src/reports/topcoder/topcoder-reports.sql.spec.ts to lock the Engagement Data country precedence in focused SQL regression coverage.
Validated with `pnpm test -- src/reports/topcoder/topcoder-reports.service.spec.ts src/reports/topcoder/topcoder-reports.sql.spec.ts`, `pnpm lint`, and `pnpm build`.
Full `pnpm test` still fails on existing SFDC suites already red on `develop`: `src/reports/sfdc/sfdc-reports.dto.spec.ts`, `src/reports/sfdc/sfdc-reports.module.spec.ts`, `src/reports/sfdc/sfdc-reports.controller.spec.ts`, and `src/reports/sfdc/sfdc-reports.service.spec.ts`.
