### PR TITLE
PM-4800: stop engagement report from using stale country fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ENGAGEMENTS_DB_URL="postgresql://user:password@localhost:5432/engagements"
 
 # The same report also reads member/profile/project data from the main
 # DATABASE_URL connection, including members.member, members.memberAddress,
-# members.memberPhone, identity.country, and projects.projects.
+# members.memberPhone, identity.country, lookups.Country, and projects.projects.
 
 # Old tc-payments database URL (used by member-tax CSV export script)
 OLD_PAYMENTS_DATABASE_URL="postgresql://user:password@localhost:5432/tc_payments?schema=public"

--- a/sql/reports/topcoder/engagement-data-members.sql
+++ b/sql/reports/topcoder/engagement-data-members.sql
@@ -4,8 +4,15 @@ SELECT
   NULLIF(BTRIM(m."firstName"), '') AS first_name,
   NULLIF(BTRIM(m."lastName"), '') AS last_name,
   NULLIF(BTRIM(m.email), '') AS email,
-  COALESCE(NULLIF(BTRIM(c.country_name), ''), NULLIF(BTRIM(m.country), ''))
-    AS country,
+  COALESCE(
+    home_code.name,
+    home_id.name,
+    comp_code.name,
+    comp_id.name,
+    NULLIF(BTRIM(m."homeCountryCode"), ''),
+    NULLIF(BTRIM(m."competitionCountryCode"), ''),
+    NULLIF(BTRIM(m.country), '')
+  ) AS country,
   preferred_address.street_addr_1,
   preferred_address.street_addr_2,
   preferred_address.city,
@@ -13,8 +20,14 @@ SELECT
   preferred_address.zip,
   preferred_phone.phone_number
 FROM members.member m
-LEFT JOIN identity.country c
-  ON c.iso_alpha3_code = m."competitionCountryCode"
+LEFT JOIN lookups."Country" AS home_code
+  ON UPPER(home_code."countryCode") = UPPER(m."homeCountryCode")
+LEFT JOIN lookups."Country" AS home_id
+  ON UPPER(home_id.id) = UPPER(m."homeCountryCode")
+LEFT JOIN lookups."Country" AS comp_code
+  ON UPPER(comp_code."countryCode") = UPPER(m."competitionCountryCode")
+LEFT JOIN lookups."Country" AS comp_id
+  ON UPPER(comp_id.id) = UPPER(m."competitionCountryCode")
 LEFT JOIN LATERAL (
   SELECT
     NULLIF(BTRIM(a."streetAddr1"), '') AS street_addr_1,

--- a/sql/reports/topcoder/engagement-data-members.sql
+++ b/sql/reports/topcoder/engagement-data-members.sql
@@ -5,14 +5,21 @@ SELECT
   NULLIF(BTRIM(m."lastName"), '') AS last_name,
   NULLIF(BTRIM(m.email), '') AS email,
   COALESCE(
-    home_code.name,
-    home_id.name,
-    comp_code.name,
-    comp_id.name,
-    NULLIF(BTRIM(m."homeCountryCode"), ''),
-    NULLIF(BTRIM(m."competitionCountryCode"), ''),
-    NULLIF(BTRIM(m.country), '')
-  ) AS country,
+    NULLIF(BTRIM(home_lookup_code.name), ''),
+    NULLIF(BTRIM(home_lookup_id.name), ''),
+    NULLIF(BTRIM(home_identity_alpha3.country_name), ''),
+    NULLIF(BTRIM(home_identity_code.country_name), ''),
+    NULLIF(BTRIM(home_identity_alpha2.country_name), '')
+  ) AS home_country,
+  COALESCE(
+    NULLIF(BTRIM(comp_lookup_code.name), ''),
+    NULLIF(BTRIM(comp_lookup_id.name), ''),
+    NULLIF(BTRIM(comp_identity_alpha3.country_name), ''),
+    NULLIF(BTRIM(comp_identity_code.country_name), ''),
+    NULLIF(BTRIM(comp_identity_alpha2.country_name), '')
+  ) AS competition_country,
+  NULLIF(BTRIM(m."homeCountryCode"), '') AS home_country_code,
+  NULLIF(BTRIM(m."competitionCountryCode"), '') AS competition_country_code,
   preferred_address.street_addr_1,
   preferred_address.street_addr_2,
   preferred_address.city,
@@ -20,14 +27,26 @@ SELECT
   preferred_address.zip,
   preferred_phone.phone_number
 FROM members.member m
-LEFT JOIN lookups."Country" AS home_code
-  ON UPPER(home_code."countryCode") = UPPER(m."homeCountryCode")
-LEFT JOIN lookups."Country" AS home_id
-  ON UPPER(home_id.id) = UPPER(m."homeCountryCode")
-LEFT JOIN lookups."Country" AS comp_code
-  ON UPPER(comp_code."countryCode") = UPPER(m."competitionCountryCode")
-LEFT JOIN lookups."Country" AS comp_id
-  ON UPPER(comp_id.id) = UPPER(m."competitionCountryCode")
+LEFT JOIN lookups."Country" AS home_lookup_code
+  ON UPPER(home_lookup_code."countryCode") = UPPER(BTRIM(m."homeCountryCode"))
+LEFT JOIN lookups."Country" AS home_lookup_id
+  ON UPPER(home_lookup_id.id) = UPPER(BTRIM(m."homeCountryCode"))
+LEFT JOIN identity.country AS home_identity_alpha3
+  ON UPPER(home_identity_alpha3.iso_alpha3_code) = UPPER(BTRIM(m."homeCountryCode"))
+LEFT JOIN identity.country AS home_identity_code
+  ON UPPER(home_identity_code.country_code) = UPPER(BTRIM(m."homeCountryCode"))
+LEFT JOIN identity.country AS home_identity_alpha2
+  ON UPPER(home_identity_alpha2.iso_alpha2_code) = UPPER(BTRIM(m."homeCountryCode"))
+LEFT JOIN lookups."Country" AS comp_lookup_code
+  ON UPPER(comp_lookup_code."countryCode") = UPPER(BTRIM(m."competitionCountryCode"))
+LEFT JOIN lookups."Country" AS comp_lookup_id
+  ON UPPER(comp_lookup_id.id) = UPPER(BTRIM(m."competitionCountryCode"))
+LEFT JOIN identity.country AS comp_identity_alpha3
+  ON UPPER(comp_identity_alpha3.iso_alpha3_code) = UPPER(BTRIM(m."competitionCountryCode"))
+LEFT JOIN identity.country AS comp_identity_code
+  ON UPPER(comp_identity_code.country_code) = UPPER(BTRIM(m."competitionCountryCode"))
+LEFT JOIN identity.country AS comp_identity_alpha2
+  ON UPPER(comp_identity_alpha2.iso_alpha2_code) = UPPER(BTRIM(m."competitionCountryCode"))
 LEFT JOIN LATERAL (
   SELECT
     NULLIF(BTRIM(a."streetAddr1"), '') AS street_addr_1,

--- a/src/reports/member/member-search.controller.ts
+++ b/src/reports/member/member-search.controller.ts
@@ -1,5 +1,17 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
 import { MemberSearchBodyDto } from "./dto/member-search.dto";
 import { MemberSearchResponseDto } from "./dto/member-search-response.dto";
 import { MemberSearchService } from "./member-search.service";

--- a/src/reports/member/member-search.service.spec.ts
+++ b/src/reports/member/member-search.service.spec.ts
@@ -56,7 +56,9 @@ describe("MemberSearchService", () => {
 
     expect(dataSql).toContain("WITH recently_active AS");
     expect(dataSql).not.toContain("requested_skills AS");
-    expect(dataSql).toContain('ORDER BY "matchIndex" DESC NULLS LAST, m.handle ASC');
+    expect(dataSql).toContain(
+      'ORDER BY "matchIndex" DESC NULLS LAST, m.handle ASC',
+    );
 
     expect(countSql).toContain("SELECT COUNT(*)::integer AS total");
 
@@ -85,7 +87,9 @@ describe("MemberSearchService", () => {
   });
 
   it("uses filter params for count query but excludes pagination params", async () => {
-    mockDbService.query.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+    mockDbService.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: 0 }]);
 
     await service.search({
       country: "us",
@@ -99,7 +103,9 @@ describe("MemberSearchService", () => {
     const dataParams = mockDbService.query.mock.calls[0][1] as unknown[];
     const countParams = mockDbService.query.mock.calls[1][1] as unknown[];
 
-    expect(dataSql).toContain('ORDER BY m.handle ASC, "matchIndex" DESC NULLS LAST');
+    expect(dataSql).toContain(
+      'ORDER BY m.handle ASC, "matchIndex" DESC NULLS LAST',
+    );
     expect(dataParams).toEqual(["us", 5, 5]);
     expect(countParams).toEqual(["us"]);
   });

--- a/src/reports/topcoder/topcoder-reports.service.spec.ts
+++ b/src/reports/topcoder/topcoder-reports.service.spec.ts
@@ -21,7 +21,10 @@ describe("TopcoderReportsService", () => {
               first_name: "Ada",
               last_name: "Lovelace",
               email: "ada@example.com",
-              country: "United States",
+              home_country: null,
+              competition_country: null,
+              home_country_code: "JPN",
+              competition_country_code: null,
               street_addr_1: "1 Main St",
               street_addr_2: null,
               city: "New York",
@@ -35,7 +38,10 @@ describe("TopcoderReportsService", () => {
               first_name: null,
               last_name: null,
               email: null,
-              country: "Canada",
+              home_country: null,
+              competition_country: "Sri Lanka",
+              home_country_code: null,
+              competition_country_code: "LKA",
               street_addr_1: null,
               street_addr_2: null,
               city: null,
@@ -114,13 +120,13 @@ describe("TopcoderReportsService", () => {
     jest.clearAllMocks();
   });
 
-  it("builds engagement data rows with DB-backed enrichment, fallbacks, and project names", async () => {
+  it("builds engagement data rows with profile-style country resolution, fallbacks, and project names", async () => {
     await expect(service.getEngagementData()).resolves.toEqual([
       {
         handle: "assigned_user",
         firstName: "Ada",
         lastName: "Lovelace",
-        country: "United States",
+        country: "Japan",
         emailId: "ada@example.com",
         phoneNumber: "+1 555 0101",
         address: "1 Main St, New York, NY, 10001",
@@ -131,7 +137,7 @@ describe("TopcoderReportsService", () => {
         handle: "applicant_user",
         firstName: "Grace",
         lastName: "Hopper",
-        country: "Canada",
+        country: "Sri Lanka",
         emailId: "applicant@example.com",
         phoneNumber: "222-222-2222",
         address: "Applicant Address",

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -645,7 +645,8 @@ export class TopcoderReportsService implements OnModuleDestroy {
    *
    * The base member list comes from the engagements database, while member
    * profile/contact fields and project names are resolved directly from the
-   * main reports database so the export stays DB-only.
+   * main reports database so the export stays DB-only. Country resolution
+   * follows the same home-country-first fallback order used by the profile UI.
    *
    * @returns One row per member with the engagement experience summary fields.
    * @throws Error when the engagements database URL is not configured.

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -134,7 +134,10 @@ type EngagementMemberRow = {
   first_name: string | null;
   last_name: string | null;
   email: string | null;
-  country: string | null;
+  home_country: string | null;
+  competition_country: string | null;
+  home_country_code: string | null;
+  competition_country_code: string | null;
   street_addr_1: string | null;
   street_addr_2: string | null;
   city: string | null;
@@ -646,7 +649,8 @@ export class TopcoderReportsService implements OnModuleDestroy {
    * The base member list comes from the engagements database, while member
    * profile/contact fields and project names are resolved directly from the
    * main reports database so the export stays DB-only. Country resolution
-   * follows the same home-country-first fallback order used by the profile UI.
+   * follows the same home-country-first profile fields used by the profile UI
+   * and avoids the stale legacy members.member.country fallback.
    *
    * @returns One row per member with the engagement experience summary fields.
    * @throws Error when the engagements database URL is not configured.
@@ -702,7 +706,7 @@ export class TopcoderReportsService implements OnModuleDestroy {
           this.toOptionalString(member?.first_name) ?? parsedName.firstName,
         lastName:
           this.toOptionalString(member?.last_name) ?? parsedName.lastName,
-        country: this.toOptionalString(member?.country),
+        country: this.resolveEngagementMemberCountry(member),
         emailId:
           this.toOptionalString(member?.email) ?? row.application_email ?? null,
         phoneNumber:
@@ -943,6 +947,24 @@ export class TopcoderReportsService implements OnModuleDestroy {
     });
 
     return membersById;
+  }
+
+  /**
+   * Resolves the report country using the same home-country-first fields the
+   * profile UI uses for member location display.
+   *
+   * @param member DB-backed member enrichment row for the engagement report.
+   * @returns Resolved country name or null when the profile has no known country.
+   */
+  private resolveEngagementMemberCountry(
+    member?: EngagementMemberRow,
+  ): string | null {
+    return (
+      this.toOptionalString(member?.home_country) ??
+      alpha3ToCountryName(member?.home_country_code) ??
+      this.toOptionalString(member?.competition_country) ??
+      alpha3ToCountryName(member?.competition_country_code)
+    );
   }
 
   /**

--- a/src/reports/topcoder/topcoder-reports.sql.spec.ts
+++ b/src/reports/topcoder/topcoder-reports.sql.spec.ts
@@ -3,11 +3,15 @@ import { SqlLoaderService } from "src/common/sql-loader.service";
 describe("Topcoder report SQL", () => {
   const sqlLoader = new SqlLoaderService();
 
-  it("uses profile-style country precedence for engagement data members", () => {
+  it("resolves engagement data countries from profile location codes instead of the stale legacy field", () => {
     const sql = sqlLoader.load("reports/topcoder/engagement-data-members.sql");
 
     expect(sql).toMatch(
-      /COALESCE\(\s*home_code\.name,\s*home_id\.name,\s*comp_code\.name,\s*comp_id\.name,\s*NULLIF\(BTRIM\(m\."homeCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\."competitionCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\.country\), ''\)\s*\)\s+AS country/,
+      /COALESCE\(\s*NULLIF\(BTRIM\(home_lookup_code\.name\), ''\),\s*NULLIF\(BTRIM\(home_lookup_id\.name\), ''\),\s*NULLIF\(BTRIM\(home_identity_alpha3\.country_name\), ''\),\s*NULLIF\(BTRIM\(home_identity_code\.country_name\), ''\),\s*NULLIF\(BTRIM\(home_identity_alpha2\.country_name\), ''\)\s*\)\s+AS home_country/,
     );
+    expect(sql).toMatch(
+      /COALESCE\(\s*NULLIF\(BTRIM\(comp_lookup_code\.name\), ''\),\s*NULLIF\(BTRIM\(comp_lookup_id\.name\), ''\),\s*NULLIF\(BTRIM\(comp_identity_alpha3\.country_name\), ''\),\s*NULLIF\(BTRIM\(comp_identity_code\.country_name\), ''\),\s*NULLIF\(BTRIM\(comp_identity_alpha2\.country_name\), ''\)\s*\)\s+AS competition_country/,
+    );
+    expect(sql).not.toMatch(/NULLIF\(BTRIM\(m\.country\), ''\)/);
   });
 });

--- a/src/reports/topcoder/topcoder-reports.sql.spec.ts
+++ b/src/reports/topcoder/topcoder-reports.sql.spec.ts
@@ -1,0 +1,13 @@
+import { SqlLoaderService } from "src/common/sql-loader.service";
+
+describe("Topcoder report SQL", () => {
+  const sqlLoader = new SqlLoaderService();
+
+  it("uses profile-style country precedence for engagement data members", () => {
+    const sql = sqlLoader.load("reports/topcoder/engagement-data-members.sql");
+
+    expect(sql).toMatch(
+      /COALESCE\(\s*home_code\.name,\s*home_id\.name,\s*comp_code\.name,\s*comp_id\.name,\s*NULLIF\(BTRIM\(m\."homeCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\."competitionCountryCode"\), ''\),\s*NULLIF\(BTRIM\(m\.country\), ''\)\s*\)\s+AS country/,
+    );
+  });
+});


### PR DESCRIPTION
What was broken
The Engagement Data report could still show the wrong country or null for some members after the first QA follow-up. Members whose profile location resolved from home or competition country codes could still export the stale legacy country value instead.

Root cause
The previous fix expanded the SQL lookup coverage, but it still collapsed country resolution into a single SQL field that fell back to members.member.country. That legacy field can be stale and does not match how the profile UI resolves member location.

What was changed
Split engagement member enrichment into separate home-country and competition-country resolution fields plus the raw profile country codes.
Resolved the final export country in the report service with the same home-country-first precedence the profile UI uses, and removed the stale members.member.country fallback.
Expanded SQL coverage to resolve country names through both lookups.Country and identity.country so legacy alpha-2, alpha-3, and lookup-id values still map correctly.
Updated the report documentation to match the current country sources.

Any added/updated tests
Updated src/reports/topcoder/topcoder-reports.service.spec.ts to cover the profile-style country precedence for the report output.
Updated src/reports/topcoder/topcoder-reports.sql.spec.ts to lock the SQL against falling back to members.member.country.
Validated with `pnpm lint`, `pnpm build`, `pnpm test -- src/reports/topcoder/topcoder-reports.service.spec.ts src/reports/topcoder/topcoder-reports.sql.spec.ts`, and `pnpm test`.
Full `pnpm test` still fails on existing SFDC suites already red on `develop`: `src/reports/sfdc/sfdc-reports.dto.spec.ts`, `src/reports/sfdc/sfdc-reports.module.spec.ts`, `src/reports/sfdc/sfdc-reports.controller.spec.ts`, and `src/reports/sfdc/sfdc-reports.service.spec.ts`.
