### PR TITLE
PM-4934: Fix SFDC payments CSV export

### DIFF
--- a/src/reports/sfdc/sfdc-reports.controller.spec.ts
+++ b/src/reports/sfdc/sfdc-reports.controller.spec.ts
@@ -1,7 +1,10 @@
 import "reflect-metadata";
 import { BadRequestException } from "@nestjs/common";
+import { INTERCEPTORS_METADATA } from "@nestjs/common/constants";
 import { Test, TestingModule } from "@nestjs/testing";
 import { plainToInstance } from "class-transformer";
+import { CsvSerializer } from "../../common/csv/csv-serializer";
+import { CsvResponseInterceptor } from "../../common/interceptors/csv-response.interceptor";
 import {
   BaFeesReportQueryDto,
   ChallengesReportQueryDto,
@@ -55,6 +58,8 @@ describe("SfdcReportsController", () => {
     const moduleRef: TestingModule = await Test.createTestingModule({
       controllers: [SfdcReportsController],
       providers: [
+        CsvSerializer,
+        CsvResponseInterceptor,
         {
           provide: SfdcReportsService,
           useValue: mockSfdcReportsService,
@@ -67,6 +72,13 @@ describe("SfdcReportsController", () => {
 
   it("compiles the controller", () => {
     expect(controller).toBeDefined();
+  });
+
+  it("enables CSV response serialization for report downloads", () => {
+    const interceptors =
+      Reflect.getMetadata(INTERCEPTORS_METADATA, SfdcReportsController) ?? [];
+
+    expect(interceptors).toContain(CsvResponseInterceptor);
   });
 
   it("returns the challenges report on success", async () => {
@@ -626,11 +638,8 @@ describe("SfdcReportsController", () => {
 
       await controller.getBaFeesReport(mockBaFeesQueryDto.byBillingAccount);
 
-      expect(mockSfdcReportsService.getBaFeesReport).toHaveBeenCalledWith(
-        expect.objectContaining({
-          groupBy: undefined,
-        }),
-      );
+      const [query] = mockSfdcReportsService.getBaFeesReport.mock.calls[0];
+      expect(query.groupBy).toBeUndefined();
     });
   });
 });

--- a/src/reports/sfdc/sfdc-reports.controller.ts
+++ b/src/reports/sfdc/sfdc-reports.controller.ts
@@ -1,8 +1,15 @@
-import { Controller, Get, Query, UseGuards } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  UseInterceptors,
+} from "@nestjs/common";
 
 import {
   ApiBearerAuth,
   ApiOperation,
+  ApiProduces,
   ApiResponse,
   ApiTags,
 } from "@nestjs/swagger";
@@ -10,6 +17,7 @@ import {
 import { PermissionsGuard } from "../../auth/guards/permissions.guard";
 import { Scopes } from "../../auth/decorators/scopes.decorator";
 import { Scopes as AppScopes } from "../../app-constants";
+import { CsvResponseInterceptor } from "../../common/interceptors/csv-response.interceptor";
 
 import { SfdcReportsService } from "./sfdc-reports.service";
 import {
@@ -31,6 +39,8 @@ import {
 import { ResponseDto } from "src/dto/api-response.dto";
 
 @ApiTags("Sfdc Reports")
+@ApiProduces("application/json", "text/csv")
+@UseInterceptors(CsvResponseInterceptor)
 @Controller("/sfdc")
 export class SfdcReportsController {
   constructor(private readonly reportsService: SfdcReportsService) {}

--- a/src/reports/sfdc/sfdc-reports.module.spec.ts
+++ b/src/reports/sfdc/sfdc-reports.module.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { CsvResponseInterceptor } from "src/common/interceptors/csv-response.interceptor";
+import { CsvSerializer } from "src/common/csv/csv-serializer";
 import { SqlLoaderService } from "src/common/sql-loader.service";
+import { DbModule } from "../../db/db.module";
 import { DbService } from "../../db/db.service";
 import { SfdcReportsController } from "./sfdc-reports.controller";
 import { SfdcReportsModule } from "./sfdc-reports.module";
@@ -23,9 +26,10 @@ describe("SfdcReportsModule", () => {
     mockSqlLoaderService.load.mockReturnValue("SELECT 1");
 
     moduleRef = await Test.createTestingModule({
-      imports: [SfdcReportsModule],
-      providers: [{ provide: DbService, useValue: mockDbService }],
+      imports: [DbModule, SfdcReportsModule],
     })
+      .overrideProvider(DbService)
+      .useValue(mockDbService)
       .overrideProvider(SqlLoaderService)
       .useValue(mockSqlLoaderService)
       .compile();
@@ -41,6 +45,12 @@ describe("SfdcReportsModule", () => {
     expect(moduleRef.get<SqlLoaderService>(SqlLoaderService)).toBe(
       mockSqlLoaderService,
     );
+    expect(moduleRef.get<CsvSerializer>(CsvSerializer)).toBeInstanceOf(
+      CsvSerializer,
+    );
+    expect(
+      moduleRef.get<CsvResponseInterceptor>(CsvResponseInterceptor),
+    ).toBeInstanceOf(CsvResponseInterceptor);
   });
 
   it("injects mocked dependencies into the service", async () => {

--- a/src/reports/sfdc/sfdc-reports.module.ts
+++ b/src/reports/sfdc/sfdc-reports.module.ts
@@ -1,10 +1,17 @@
 import { Module } from "@nestjs/common";
+import { CsvSerializer } from "../../common/csv/csv-serializer";
+import { CsvResponseInterceptor } from "../../common/interceptors/csv-response.interceptor";
+import { SqlLoaderService } from "../../common/sql-loader.service";
 import { SfdcReportsController } from "./sfdc-reports.controller";
 import { SfdcReportsService } from "./sfdc-reports.service";
-import { SqlLoaderService } from "../../common/sql-loader.service";
 
 @Module({
   controllers: [SfdcReportsController],
-  providers: [SfdcReportsService, SqlLoaderService],
+  providers: [
+    SfdcReportsService,
+    SqlLoaderService,
+    CsvSerializer,
+    CsvResponseInterceptor,
+  ],
 })
 export class SfdcReportsModule {}


### PR DESCRIPTION
What was broken
Reports app CSV downloads for SFDC reports, including Payments, saved JSON response bodies into .csv files.

Root cause
The SFDC reports controller did not use the existing CSV response interceptor, so Accept: text/csv requests still returned the controller data as JSON.

What was changed
Enabled application/json and text/csv production on the SFDC reports controller, attached the existing CsvResponseInterceptor, and registered the CSV serializer/interceptor providers in the SFDC reports module.

Any added/updated tests
Added SFDC controller and module coverage for CSV interceptor wiring. Updated the BA fees optional groupBy assertion to accept an omitted optional property while still verifying the value is undefined.

Focused SFDC tests, changed-file ESLint, and build passed. The full test suite was run and still fails on existing unrelated SFDC DTO validation, TaaS empty-array, and member-search SQL assertion failures from the current develop baseline.
