### PR TITLE
Pm 4931 Fix query to account for verified skills coming from submissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ workflows:
           branches:
             only:
               - develop
-              - PM-4949
+              - PM-4931
 
     # Production builds are exectuted only on tagged commits to the
     # master branch.

--- a/src/reports/member/dto/member-search-response.dto.ts
+++ b/src/reports/member/dto/member-search-response.dto.ts
@@ -9,7 +9,7 @@ export class MatchedSkillDto {
 
   @ApiProperty({
     description:
-      "True when the member has at least one challenge-win event for this skill.",
+      "True when the member has win credit and/or at least one platform skill event for this skill (e.g. submission, review); false for self-declared only.",
   })
   isVerified!: boolean;
 

--- a/src/reports/member/dto/member-search-response.dto.ts
+++ b/src/reports/member/dto/member-search-response.dto.ts
@@ -9,7 +9,7 @@ export class MatchedSkillDto {
 
   @ApiProperty({
     description:
-      "True when the member has win credit and/or at least one platform skill event for this skill (e.g. submission, review); false for self-declared only.",
+      "True for platform-backed skill activity (wins and/or skill events). Matched skills only include these, not self-attested-only skills.",
   })
   isVerified!: boolean;
 

--- a/src/reports/member/member-search.service.spec.ts
+++ b/src/reports/member/member-search.service.spec.ts
@@ -227,6 +227,9 @@ describe("MemberSearchService", () => {
 
     expect(dataSql).toContain("requested_skills AS");
     expect(dataSql).toContain("INNER JOIN user_match_data umd");
+    expect(dataSql).toContain("THEN COUNT(DISTINCT usd.skill_id) =");
+    expect(dataSql).toContain("ELSE COUNT(DISTINCT usd.skill_id) >= 1");
+    expect(dataSql).not.toContain("usd.wins >= rs.min_wins");
     expect(dataParams).toContainEqual([skillA, skillB]);
     expect(dataParams).toContainEqual([5, 0]);
     expect(dataParams).toContain("AND");

--- a/src/reports/member/member-search.service.spec.ts
+++ b/src/reports/member/member-search.service.spec.ts
@@ -226,6 +226,9 @@ describe("MemberSearchService", () => {
     expect(validationParams).toEqual([[skillA, skillB]]);
 
     expect(dataSql).toContain("requested_skills AS");
+    expect(dataSql).toContain(
+      "(usd.wins >= rs.min_wins OR usd.submitted > 0)",
+    );
     expect(dataSql).toContain("INNER JOIN user_match_data umd");
     expect(dataSql).toContain("THEN COUNT(DISTINCT usd.skill_id) =");
     expect(dataSql).toContain("ELSE COUNT(DISTINCT usd.skill_id) >= 1");

--- a/src/reports/member/member-search.service.spec.ts
+++ b/src/reports/member/member-search.service.spec.ts
@@ -142,7 +142,6 @@ describe("MemberSearchService", () => {
     expect(dataSql).not.toContain(
       'EXISTS (SELECT 1 FROM recently_active ra WHERE ra.user_id = m."userId")',
     );
-    expect(dataSql).not.toContain("COALESCE(m.verified, false) = true");
   });
 
   it("adds profileComplete CTE/join only when enabled and keeps count params free of pagination", async () => {
@@ -226,13 +225,11 @@ describe("MemberSearchService", () => {
     expect(validationParams).toEqual([[skillA, skillB]]);
 
     expect(dataSql).toContain("requested_skills AS");
-    expect(dataSql).toContain(
-      "(usd.wins >= rs.min_wins OR usd.submitted > 0)",
-    );
+    expect(dataSql).toContain("FILTER (WHERE usd.wins > 0 OR usd.submitted > 0)");
     expect(dataSql).toContain("INNER JOIN user_match_data umd");
-    expect(dataSql).toContain("THEN COUNT(DISTINCT usd.skill_id) =");
-    expect(dataSql).toContain("ELSE COUNT(DISTINCT usd.skill_id) >= 1");
-    expect(dataSql).not.toContain("usd.wins >= rs.min_wins");
+    expect(dataSql).toContain("THEN COUNT(DISTINCT CASE");
+    expect(dataSql).toContain("ELSE COUNT(DISTINCT CASE");
+    expect(dataSql).toContain("(usd.wins >= rs.min_wins OR usd.submitted > 0)");
     expect(dataParams).toContainEqual([skillA, skillB]);
     expect(dataParams).toContainEqual([5, 0]);
     expect(dataParams).toContain("AND");

--- a/src/reports/member/member-search.service.ts
+++ b/src/reports/member/member-search.service.ts
@@ -141,9 +141,8 @@ qualifying_users AS (
   GROUP BY usd.user_id
   HAVING
     CASE WHEN ${pSearchType} = 'AND'
-      THEN COUNT(DISTINCT CASE WHEN usd.wins >= rs.min_wins THEN usd.skill_id END)
-             = ${pNumSkills}::integer
-      ELSE COUNT(DISTINCT CASE WHEN usd.wins >= rs.min_wins THEN usd.skill_id END) >= 1
+      THEN COUNT(DISTINCT usd.skill_id) = ${pNumSkills}::integer
+      ELSE COUNT(DISTINCT usd.skill_id) >= 1
     END
 ),
 user_match_data AS (

--- a/src/reports/member/member-search.service.ts
+++ b/src/reports/member/member-search.service.ts
@@ -141,8 +141,13 @@ qualifying_users AS (
   GROUP BY usd.user_id
   HAVING
     CASE WHEN ${pSearchType} = 'AND'
-      THEN COUNT(DISTINCT usd.skill_id) = ${pNumSkills}::integer
-      ELSE COUNT(DISTINCT usd.skill_id) >= 1
+      THEN COUNT(DISTINCT CASE
+        WHEN (usd.wins >= rs.min_wins OR usd.submitted > 0)
+        THEN usd.skill_id END)
+             = ${pNumSkills}::integer
+      ELSE COUNT(DISTINCT CASE
+        WHEN (usd.wins >= rs.min_wins OR usd.submitted > 0)
+        THEN usd.skill_id END) >= 1
     END
 ),
 user_match_data AS (
@@ -160,7 +165,7 @@ user_match_data AS (
       jsonb_build_object(
         'id',         usd.skill_id::text,
         'name',       usd.skill_name,
-        'isVerified', usd.wins > 0,
+        'isVerified', (usd.wins > 0 OR usd.submitted > 0),
         'wins',       usd.wins,
         'submitted',  usd.submitted
       )

--- a/src/reports/member/member-search.service.ts
+++ b/src/reports/member/member-search.service.ts
@@ -153,23 +153,29 @@ qualifying_users AS (
 user_match_data AS (
   SELECT
     usd.user_id,
-    SUM(
-      1.0
-      + LEAST(usd.wins::float / 100.0, 0.5)
-      + CASE WHEN usd.submitted > 0
-          THEN (usd.wins::float / usd.submitted::float) * 0.5
-          ELSE 0.0
-        END
+    COALESCE(
+      SUM(
+        1.0
+        + LEAST(usd.wins::float / 100.0, 0.5)
+        + CASE WHEN usd.submitted > 0
+            THEN (usd.wins::float / usd.submitted::float) * 0.5
+            ELSE 0.0
+          END
+      ) FILTER (WHERE usd.wins > 0 OR usd.submitted > 0),
+      0.0
     ) AS total_skill_points,
-    jsonb_agg(
-      jsonb_build_object(
-        'id',         usd.skill_id::text,
-        'name',       usd.skill_name,
-        'isVerified', (usd.wins > 0 OR usd.submitted > 0),
-        'wins',       usd.wins,
-        'submitted',  usd.submitted
-      )
-      ORDER BY usd.skill_name
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id',         usd.skill_id::text,
+          'name',       usd.skill_name,
+          'isVerified', (usd.wins > 0 OR usd.submitted > 0),
+          'wins',       usd.wins,
+          'submitted',  usd.submitted
+        )
+        ORDER BY usd.skill_name
+      ) FILTER (WHERE usd.wins > 0 OR usd.submitted > 0),
+      '[]'::jsonb
     ) AS matched_skills
   FROM user_skill_data usd
   WHERE usd.user_id IN (SELECT user_id FROM qualifying_users)


### PR DESCRIPTION
Fix query to account for verified skill matches coming from submissions and not only wins

https://topcoder.atlassian.net/browse/PM-4931