### PR TITLE
PM-4961 Add TM to SFDC access roles

### DIFF
--- a/src/app-constants.ts
+++ b/src/app-constants.ts
@@ -55,6 +55,9 @@ const challengeReportAccessRoles = [
   UserRoles.TalentManager,
 ] as const;
 
+/** Human role mapping for SFDC report scopes (admins still bypass via `hasAdminRole`). */
+const sfdcReportsTalentManagerRoles = [UserRoles.TalentManager] as const;
+
 export const ScopeRoleAccess: Record<string, readonly string[]> = {
   [Scopes.Challenge.History]: challengeReportAccessRoles,
   [Scopes.Challenge.Registrants]: challengeReportAccessRoles,
@@ -63,6 +66,13 @@ export const ScopeRoleAccess: Record<string, readonly string[]> = {
   [Scopes.Challenge.Submitters]: challengeReportAccessRoles,
   [Scopes.Challenge.ValidSubmitters]: challengeReportAccessRoles,
   [Scopes.Challenge.Winners]: challengeReportAccessRoles,
+  [Scopes.SFDC.PaymentsReport]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.ChallengesReport]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.BA]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.TaasJobs]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.TaasResourceBookings]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.TaasMemberVerification]: sfdcReportsTalentManagerRoles,
+  [Scopes.SFDC.WesternUnionPayments]: sfdcReportsTalentManagerRoles,
   [Scopes.Member.EngagementData]: [UserRoles.TalentManager],
   [Scopes.Member.RecentMemberData]: [UserRoles.TalentManager],
   [Scopes.Member.MemberSearch]: [UserRoles.TalentManager],

--- a/src/auth/permissions.util.spec.ts
+++ b/src/auth/permissions.util.spec.ts
@@ -64,4 +64,46 @@ describe("permissions.util", () => {
       ),
     ).toBe(false);
   });
+
+  it("allows talent manager role for SFDC payments report scope", () => {
+    expect(
+      hasAccessToScopes(
+        {
+          roles: ["Topcoder Talent Manager"],
+        },
+        [Scopes.SFDC.PaymentsReport],
+      ),
+    ).toBe(true);
+  });
+
+  it("denies product manager role for SFDC payments report scope", () => {
+    expect(
+      hasAccessToScopes(
+        {
+          roles: ["Topcoder Product Manager"],
+        },
+        [Scopes.SFDC.PaymentsReport],
+      ),
+    ).toBe(false);
+  });
+
+  it("allows administrator role for SFDC payments report scope", () => {
+    expect(
+      hasAccessToScopes(
+        {
+          roles: ["Administrator"],
+        },
+        [Scopes.SFDC.PaymentsReport],
+      ),
+    ).toBe(true);
+  });
+
+  it("allows talent manager role for other SFDC report scopes", () => {
+    expect(
+      hasAccessToScopes(
+        { roles: ["Topcoder Talent Manager"] },
+        [Scopes.SFDC.BA, Scopes.SFDC.ChallengesReport],
+      ),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
Allow TMs to view BA details and payments
Gives access to TMs to view SFDC reports too

https://topcoder.atlassian.net/browse/PM-4961 - latest comment