### PR TITLE
PM-5075 - fix matched skills

### DIFF
--- a/src/reports/member/member-search.service.ts
+++ b/src/reports/member/member-search.service.ts
@@ -113,6 +113,7 @@ user_skill_data AS (
     usws.wins,
     usws.submitted
   FROM skills.user_skill_win_summary usws
+  JOIN requested_skills rs ON rs.skill_id = usws.skill_id
   JOIN skills.skill     sk ON sk.id = usws.skill_id AND sk.deleted_at IS NULL
   WHERE usws.user_id IN (SELECT user_id FROM active_members)
 ),


### PR DESCRIPTION
This pull request makes a small but important change to the `user_skill_data` query in `member-search.service.ts` to ensure only requested skills are included in the results.

* Added a join between `user_skill_win_summary` and `requested_skills` to filter the skills based on those that are requested.