### PR TITLE
PM-5073 - Allow search by preferred roles, remove restriction about skills

### DIFF
--- a/src/reports/member/dto/member-search.dto.ts
+++ b/src/reports/member/dto/member-search.dto.ts
@@ -85,6 +85,17 @@ export class MemberSearchBodyDto {
 
   @ApiPropertyOptional({
     description:
+      "Filter by multiple preferred role values from the member's open-to-work personalization trait.",
+    type: [String],
+    example: ["AI_ML_ENGINEER", "FULL_STACK_DEVELOPER"],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  preferredRoles?: string[];
+
+  @ApiPropertyOptional({
+    description:
       "Filter by multiple country names or country codes (case-insensitive).",
     type: [String],
     example: ["US", "Australia"],

--- a/src/reports/member/member-search.service.ts
+++ b/src/reports/member/member-search.service.ts
@@ -54,6 +54,7 @@ export class MemberSearchService {
       verifiedProfile,
       profileComplete,
       countries,
+      preferredRoles,
       sortBy = "matchIndex",
       sortOrder = "desc",
       page = 1,
@@ -225,6 +226,14 @@ member_address AS (
         ]
       : [];
 
+    const normalizedPreferredRoles = Array.isArray(preferredRoles)
+      ? [
+          ...new Set(
+            preferredRoles.map((value) => String(value).trim()).filter(Boolean),
+          ),
+        ]
+      : [];
+
     if (normalizedCountries.length > 0) {
       const pCountries = p(normalizedCountries);
       where.push(
@@ -232,6 +241,30 @@ member_address AS (
           m."homeCountryCode" = ANY(${pCountries}::text[])
           OR m."competitionCountryCode" = ANY(${pCountries}::text[])
           OR UPPER(m.country) = ANY(${pCountries}::text[])
+        )`,
+      );
+    }
+
+    if (normalizedPreferredRoles.length > 0) {
+      const pPreferredRoles = p(
+        normalizedPreferredRoles.map((value) => value.toUpperCase()),
+      );
+      where.push(
+        `EXISTS (
+          SELECT 1
+          FROM members."memberTraits" mtpr
+          INNER JOIN members."memberTraitPersonalization" mtpp
+            ON mtpp."memberTraitId" = mtpr.id
+          WHERE mtpr."userId" = m."userId"
+            AND mtpp.key = 'openToWork'
+            AND mtpp.value IS NOT NULL
+            AND mtpp.value::jsonb ? 'preferredRoles'
+            AND jsonb_typeof(mtpp.value::jsonb -> 'preferredRoles') = 'array'
+            AND EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements_text(mtpp.value::jsonb -> 'preferredRoles') pr
+              WHERE UPPER(pr) = ANY(${pPreferredRoles}::text[])
+            )
         )`,
       );
     }
@@ -316,10 +349,20 @@ member_address AS (
     // ---------------------------------------------------------------- queries
     const ctesBlock = ctes.join(",\n");
     const direction = sortOrder === "asc" ? "ASC" : "DESC";
-    const orderByClause =
-      sortBy === "handle"
-        ? `m.handle ${direction}, "matchIndex" DESC NULLS LAST`
-        : `"matchIndex" ${direction} NULLS LAST, m.handle ASC`;
+    const fallbackPreferredRoleOrder =
+      deduped.length === 0 && normalizedPreferredRoles.length > 0;
+    let orderByClause = "";
+
+    if (sortBy === "handle") {
+      orderByClause = `m.handle ${direction}, "matchIndex" DESC NULLS LAST`;
+    } else if (fallbackPreferredRoleOrder) {
+      orderByClause =
+        `EXISTS (SELECT 1 FROM recently_active ra WHERE ra.user_id = m."userId") DESC, ` +
+        `COALESCE(m."availableForGigs", false) DESC, m.handle ASC`;
+    } else {
+      orderByClause = `"matchIndex" ${direction} NULLS LAST, m.handle ASC`;
+    }
+
     const profileCompleteJoin =
       profileComplete === true
         ? `INNER JOIN profile_complete_filtered pcf ON pcf.user_id = m."userId"`
@@ -344,7 +387,7 @@ SELECT
 FROM members.member m
 INNER JOIN filtered_members fm ON fm.user_id = m."userId"
 ${profileCompleteJoin}
-LEFT JOIN user_match_data umd ON umd.user_id = m."userId"
+${deduped.length > 0 ? 'LEFT JOIN user_match_data umd ON umd.user_id = m."userId"' : ""}
 LEFT JOIN verified_via_trolley vt ON vt.user_id = m."userId"
 LEFT JOIN member_address    maddr ON maddr."userId" = m."userId"
 ORDER BY ${orderByClause}


### PR DESCRIPTION
This pull request enhances the member search functionality by adding support for filtering and sorting members based on their preferred roles, as specified in their open-to-work personalization trait. The changes include updates to the API DTO, query normalization, SQL filtering, and ordering logic to ensure accurate and relevant search results.

**Preferred Roles Filtering and Sorting:**

* Added a new optional `preferredRoles` array property to the `MemberSearchBodyDto` to allow filtering members by their preferred roles from the open-to-work personalization trait.
* Updated the `MemberSearchService` to accept the `preferredRoles` parameter and normalize its values for consistent processing. [[1]](diffhunk://#diff-a44c76ad2dc02b9fc2eea5cebf20df98fb234bdb3fa1fe0e235da81eb8ab9b89R57) [[2]](diffhunk://#diff-a44c76ad2dc02b9fc2eea5cebf20df98fb234bdb3fa1fe0e235da81eb8ab9b89R229-R236)
* Enhanced the SQL query to filter members whose open-to-work personalization trait contains any of the specified preferred roles, ensuring case-insensitive matching.

**Ordering Improvements:**

* Modified the result ordering logic to prioritize recently active users and those available for gigs when only `preferredRoles` filtering is applied and no skills are specified; otherwise, default ordering by match index and handle is used.
* Adjusted SQL `LEFT JOIN` logic to only join `user_match_data` when skill filters are present, optimizing query performance.