### PR TITLE
PM-5349: allow Talent Managers to access Talent report API

### DIFF
--- a/src/reports/member/guards/member-talent-report.guard.spec.ts
+++ b/src/reports/member/guards/member-talent-report.guard.spec.ts
@@ -68,14 +68,24 @@ describe("MemberTalentReportGuard", () => {
     ).toBe(true);
   });
 
-  it("denies talent manager users", () => {
-    expect(() =>
+  it("allows talent manager users", () => {
+    expect(
       guard.canActivate(
         createExecutionContext({
           roles: [UserRoles.TalentManager],
         }),
       ),
-    ).toThrow(ForbiddenException);
+    ).toBe(true);
+  });
+
+  it("allows role claim with topcoder talent manager prefix", () => {
+    expect(
+      guard.canActivate(
+        createExecutionContext({
+          role: "Topcoder Talent Manager",
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("denies machine clients without all reports scope", () => {

--- a/src/reports/member/guards/member-talent-report.guard.ts
+++ b/src/reports/member/guards/member-talent-report.guard.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   UnauthorizedException,
 } from "@nestjs/common";
-import { Scopes } from "src/app-constants";
+import { Scopes, UserRoles } from "src/app-constants";
 import {
   AuthUserLike,
   getNormalizedRoles,
@@ -13,9 +13,13 @@ import {
   hasAdminRole,
 } from "../../../auth/permissions.util";
 
+const allowedHumanRoles = new Set<string>([
+  UserRoles.TalentManager.toLowerCase(),
+]);
+
 /**
- * Allows only administrator users, or machine clients with all-reports scope,
- * to access the open-to-work Talent report and contact export.
+ * Allows administrator and Talent Manager users, or machine clients with
+ * all-reports scope, to access the open-to-work Talent report and contact export.
  */
 @Injectable()
 export class MemberTalentReportGuard implements CanActivate {
@@ -38,7 +42,12 @@ export class MemberTalentReportGuard implements CanActivate {
       );
     }
 
-    if (hasAdminRole(getNormalizedRoles(authUser))) {
+    const roles = getNormalizedRoles(authUser);
+
+    if (
+      hasAdminRole(roles) ||
+      roles.some((role) => allowedHumanRoles.has(role))
+    ) {
       return true;
     }
 

--- a/src/reports/member/member-search.controller.ts
+++ b/src/reports/member/member-search.controller.ts
@@ -35,7 +35,7 @@ export class MemberSearchController {
   constructor(private readonly memberSearchService: MemberSearchService) {}
 
   /**
-   * Returns dashboard data for the admin-only open-to-work Talent report.
+   * Returns dashboard data for the open-to-work Talent report.
    * @param query Role, availability, and pagination filters.
    * @returns Dashboard summary and paginated member rows.
    */
@@ -45,11 +45,11 @@ export class MemberSearchController {
     summary: "List open-to-work members by preferred role",
     description:
       "Returns open-to-work member totals, preferred-role counts, and a paginated member list. " +
-      "Accessible by Administrator users only.",
+      "Accessible by Administrator and Talent Manager users only.",
   })
   @ApiResponse({ status: 200, type: OpenToWorkTalentResponseDto })
   @ApiResponse({ status: 401, description: "Unauthenticated" })
-  @ApiResponse({ status: 403, description: "Forbidden – admin role required" })
+  @ApiResponse({ status: 403, description: "Forbidden – insufficient role" })
   getOpenToWorkTalent(
     @Query() query: OpenToWorkTalentQueryDto,
   ): Promise<OpenToWorkTalentResponseDto> {
@@ -69,11 +69,11 @@ export class MemberSearchController {
     summary: "Export open-to-work members by preferred role",
     description:
       "Exports open-to-work members with email and phone fields. " +
-      "Accessible by Administrator users only.",
+      "Accessible by Administrator and Talent Manager users only.",
   })
   @ApiResponse({ status: 200, description: "Export successful." })
   @ApiResponse({ status: 401, description: "Unauthenticated" })
-  @ApiResponse({ status: 403, description: "Forbidden – admin role required" })
+  @ApiResponse({ status: 403, description: "Forbidden – insufficient role" })
   exportOpenToWorkTalent(@Query() query: OpenToWorkTalentQueryDto) {
     return this.memberSearchService.exportOpenToWorkTalent(query);
   }


### PR DESCRIPTION
What was broken
QA reported that Talent Manager role users still could not access the open-to-work Talent report API.

Root cause
The previous API fix guarded the Talent JSON and CSV endpoints for administrators only, even though the follow-up requirement allows Talent Manager users too.

What was changed
Updated the Talent report guard to allow Talent Manager users in addition to administrators and all-reports machine clients. Updated endpoint documentation and Swagger 403 descriptions to match the expanded role access.

Any added/updated tests
Updated MemberTalentReportGuard tests to allow Talent Manager roles, including the Topcoder-prefixed role claim.

Passed: source ~/.nvm/nvm.sh && nvm use && pnpm test -- member-talent-report
Passed: source ~/.nvm/nvm.sh && nvm use && pnpm lint
Passed: source ~/.nvm/nvm.sh && nvm use && pnpm build
Ran: source ~/.nvm/nvm.sh && nvm use && pnpm test. The full suite still has unrelated existing SFDC and report-directory failures outside the Talent report guard change.
