### PR TITLE
PM-5719: Add member payment dashboard data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ The Reports Portal dashboard API is available under
 `/v6/reports/dashboard`:
 
 - `GET /v6/reports/dashboard` returns all dashboards, keyed as
-  `newSignups`, `membersPaid`, and `challengeParticipation`.
+  `newSignups`, `membersPaid`, `challengeParticipation`,
+  `memberPaymentByMonth`, and `memberPaymentByCustomer`.
 - `GET /v6/reports/dashboard/:dashboard` returns one dashboard. Supported
-  slugs are `new-signups`, `members-paid`, and `challenge-participation`.
+  slugs are `new-signups`, `members-paid`, `challenge-participation`,
+  `member-payment-by-month`, and `member-payment-by-customer`.
 - `GET /v6/reports/dashboard/export` downloads all monthly dashboard rows as
   a flat CSV.
 - `GET /v6/reports/dashboard/:dashboard/export` downloads one dashboard as a
@@ -24,8 +26,9 @@ All endpoints accept optional ISO-8601 `startDate` (inclusive) and `endDate`
 (exclusive) query parameters. With neither bound, the monthly series covers
 the latest six UTC calendar months, including the current month. With one
 bound, the other is derived six calendar months away. The response always
-includes the resolved timestamps, zero-filled calendar months, and an
-all-time summary.
+includes the resolved timestamps and zero-filled calendar months. The signup,
+members-paid, and challenge-participation dashboards also include an all-time
+summary.
 
 Dashboard figures use these shared definitions:
 
@@ -34,6 +37,10 @@ Dashboard figures use these shared definitions:
 - Paid-member activity requires a `PAID` finance payment for a `PAYMENT`
   winning. Its event timestamp is `date_paid`, falling back to `created_at`.
   Members are deduplicated within each payment bucket and month.
+- Member-payment values use the latest payment version and sum `gross_amount`,
+  falling back to `total_amount`. The payment-by-customer dashboard ranks the
+  top five billing-account clients across the selected range and groups all
+  unnamed or remaining clients under `Other Customers`.
 - Registrations are Submitter resource creation events. Submissions are
   non-deleted review submission events, using `submittedDate` and falling
   back to `createdAt`. Each category is deduplicated independently by member

--- a/sql/reports/dashboard/member-payment-by-customer.sql
+++ b/sql/reports/dashboard/member-payment-by-customer.sql
@@ -1,0 +1,147 @@
+-- Monthly paid-member values split by the selected range's top five clients.
+--
+-- Parameters:
+--   $1 timestamptz - inclusive reporting range start
+--   $2 timestamptz - exclusive reporting range end
+--
+-- The same ranked customer series is used for every month. Payments for
+-- unranked or unnamed clients are grouped under Other Customers.
+-- Billing-account ids are normalized and compared as text so the historical
+-- zero sentinel falls back to challenge billing without unsafe integer casts.
+WITH bounds AS (
+  SELECT
+    $1::timestamptz AT TIME ZONE 'UTC' AS start_at,
+    $2::timestamptz AT TIME ZONE 'UTC' AS end_at
+),
+months AS (
+  SELECT GENERATE_SERIES(
+    DATE_TRUNC('month', b.start_at),
+    DATE_TRUNC('month', b.end_at - INTERVAL '1 microsecond'),
+    INTERVAL '1 month'
+  ) AS month_start
+  FROM bounds b
+),
+latest_payment_versions AS MATERIALIZED (
+  SELECT
+    p.winnings_id,
+    MAX(p.version) AS max_version
+  FROM finance.payment p
+  GROUP BY p.winnings_id
+),
+paid_events AS MATERIALIZED (
+  SELECT
+    COALESCE(p.date_paid, p.created_at) AS paid_at,
+    COALESCE(p.gross_amount, p.total_amount, 0) AS amount,
+    NULLIF(TRIM(cl.id), '') AS customer_id,
+    NULLIF(TRIM(cl.name), '') AS customer_label
+  FROM finance.payment p
+  JOIN latest_payment_versions lpv
+    ON lpv.winnings_id = p.winnings_id
+   AND lpv.max_version = p.version
+  JOIN finance.winnings w
+    ON w.winning_id = p.winnings_id
+  LEFT JOIN challenges."Challenge" c
+    ON c.id = w.external_id
+  LEFT JOIN challenges."ChallengeBilling" cb
+    ON cb."challengeId" = c.id
+  LEFT JOIN "billing-accounts"."BillingAccount" payment_ba
+    ON payment_ba.id::text = NULLIF(
+      TRIM(LEADING '0' FROM TRIM(p.billing_account)),
+      ''
+    )
+  LEFT JOIN "billing-accounts"."BillingAccount" challenge_ba
+    ON challenge_ba.id::text = NULLIF(
+      TRIM(LEADING '0' FROM TRIM(cb."billingAccountId")),
+      ''
+    )
+  LEFT JOIN "billing-accounts"."Client" cl
+    ON cl.id = COALESCE(payment_ba."clientId", challenge_ba."clientId")
+  WHERE p.payment_status = 'PAID'
+    AND w.type = 'PAYMENT'
+    AND COALESCE(p.date_paid, p.created_at) IS NOT NULL
+    AND NULLIF(TRIM(w.winner_id), '') IS NOT NULL
+    AND w.category::text IS DISTINCT FROM 'TOPGEAR_PAYMENT'
+),
+selected_events AS (
+  SELECT pe.*
+  FROM paid_events pe
+  CROSS JOIN bounds b
+  WHERE pe.paid_at >= b.start_at
+    AND pe.paid_at < b.end_at
+),
+customer_totals AS (
+  SELECT
+    se.customer_id,
+    se.customer_label,
+    SUM(se.amount) AS total_amount
+  FROM selected_events se
+  WHERE se.customer_id IS NOT NULL
+    AND se.customer_label IS NOT NULL
+  GROUP BY se.customer_id, se.customer_label
+),
+ranked_customers AS (
+  SELECT
+    ct.customer_id,
+    ct.customer_label,
+    ROW_NUMBER() OVER (
+      ORDER BY
+        ct.total_amount DESC,
+        LOWER(ct.customer_label),
+        ct.customer_label,
+        ct.customer_id
+    ) AS series_order
+  FROM customer_totals ct
+),
+top_customers AS (
+  SELECT
+    rc.customer_id,
+    rc.customer_label,
+    rc.series_order
+  FROM ranked_customers rc
+  WHERE rc.series_order <= 5
+),
+series AS (
+  SELECT
+    'customer-' || tc.customer_id AS series_key,
+    tc.customer_id,
+    tc.customer_label,
+    tc.series_order
+  FROM top_customers tc
+
+  UNION ALL
+
+  SELECT
+    'other-customers' AS series_key,
+    NULL::text AS customer_id,
+    'Other Customers' AS customer_label,
+    6 AS series_order
+),
+monthly_amounts AS (
+  SELECT
+    DATE_TRUNC('month', se.paid_at) AS month_start,
+    COALESCE(
+      'customer-' || tc.customer_id,
+      'other-customers'
+    ) AS series_key,
+    SUM(se.amount) AS amount
+  FROM selected_events se
+  LEFT JOIN top_customers tc
+    ON tc.customer_id = se.customer_id
+   AND tc.customer_label = se.customer_label
+  GROUP BY
+    DATE_TRUNC('month', se.paid_at),
+    COALESCE('customer-' || tc.customer_id, 'other-customers')
+)
+SELECT
+  TO_CHAR(m.month_start, 'YYYY-MM-01') AS month,
+  s.series_key,
+  s.customer_id,
+  s.customer_label,
+  s.series_order,
+  COALESCE(ma.amount, 0) AS amount
+FROM months m
+CROSS JOIN series s
+LEFT JOIN monthly_amounts ma
+  ON ma.month_start = m.month_start
+ AND ma.series_key = s.series_key
+ORDER BY m.month_start, s.series_order;

--- a/sql/reports/dashboard/member-payment-by-month.sql
+++ b/sql/reports/dashboard/member-payment-by-month.sql
@@ -1,0 +1,87 @@
+-- Monthly paid-member values split by canonical payment bucket.
+--
+-- Parameters:
+--   $1 timestamptz - inclusive reporting range start
+--   $2 timestamptz - exclusive reporting range end
+--
+-- Only the latest version of each payment is considered. Gross amount is the
+-- preferred member-payment value, with total amount used as a fallback.
+WITH bounds AS (
+  SELECT
+    $1::timestamptz AT TIME ZONE 'UTC' AS start_at,
+    $2::timestamptz AT TIME ZONE 'UTC' AS end_at
+),
+months AS (
+  SELECT GENERATE_SERIES(
+    DATE_TRUNC('month', b.start_at),
+    DATE_TRUNC('month', b.end_at - INTERVAL '1 microsecond'),
+    INTERVAL '1 month'
+  ) AS month_start
+  FROM bounds b
+),
+latest_payment_versions AS MATERIALIZED (
+  SELECT
+    p.winnings_id,
+    MAX(p.version) AS max_version
+  FROM finance.payment p
+  GROUP BY p.winnings_id
+),
+paid_events AS MATERIALIZED (
+  SELECT
+    COALESCE(p.date_paid, p.created_at) AS paid_at,
+    COALESCE(p.gross_amount, p.total_amount, 0) AS amount,
+    CASE
+      WHEN w.category::text = 'TAAS_PAYMENT' THEN 'taas'
+      WHEN w.category::text = 'ENGAGEMENT_PAYMENT' THEN 'engagement'
+      WHEN w.category::text IN (
+        'TASK_PAYMENT',
+        'TASK_REVIEW_PAYMENT',
+        'TASK_COPILOT_PAYMENT',
+        'DEPLOYMENT_TASK_PAYMENT',
+        'PROJECT_DEPLOYMENT_TASK_PAYMENT'
+      ) THEN 'task'
+      ELSE 'challenge'
+    END AS payment_type
+  FROM finance.payment p
+  JOIN latest_payment_versions lpv
+    ON lpv.winnings_id = p.winnings_id
+   AND lpv.max_version = p.version
+  JOIN finance.winnings w
+    ON w.winning_id = p.winnings_id
+  WHERE p.payment_status = 'PAID'
+    AND w.type = 'PAYMENT'
+    AND COALESCE(p.date_paid, p.created_at) IS NOT NULL
+    AND NULLIF(TRIM(w.winner_id), '') IS NOT NULL
+    AND w.category::text IS DISTINCT FROM 'TOPGEAR_PAYMENT'
+),
+selected_months AS (
+  SELECT
+    DATE_TRUNC('month', pe.paid_at) AS month_start,
+    COALESCE(SUM(pe.amount) FILTER (
+      WHERE pe.payment_type = 'taas'
+    ), 0) AS taas,
+    COALESCE(SUM(pe.amount) FILTER (
+      WHERE pe.payment_type = 'task'
+    ), 0) AS task,
+    COALESCE(SUM(pe.amount) FILTER (
+      WHERE pe.payment_type = 'challenge'
+    ), 0) AS challenge,
+    COALESCE(SUM(pe.amount) FILTER (
+      WHERE pe.payment_type = 'engagement'
+    ), 0) AS engagement
+  FROM paid_events pe
+  CROSS JOIN bounds b
+  WHERE pe.paid_at >= b.start_at
+    AND pe.paid_at < b.end_at
+  GROUP BY DATE_TRUNC('month', pe.paid_at)
+)
+SELECT
+  TO_CHAR(m.month_start, 'YYYY-MM-01') AS month,
+  COALESCE(sm.taas, 0) AS taas,
+  COALESCE(sm.task, 0) AS task,
+  COALESCE(sm.challenge, 0) AS challenge,
+  COALESCE(sm.engagement, 0) AS engagement
+FROM months m
+LEFT JOIN selected_months sm
+  ON sm.month_start = m.month_start
+ORDER BY m.month_start;

--- a/src/reports/dashboard/dashboard-reports.controller.spec.ts
+++ b/src/reports/dashboard/dashboard-reports.controller.spec.ts
@@ -2,6 +2,7 @@ import { CsvSerializer } from "../../common/csv/csv-serializer";
 import {
   DashboardExportRowDto,
   DashboardSlug,
+  MemberPaymentByCustomerDashboardDto,
   NewSignupsDashboardDto,
 } from "./dashboard-reports.dto";
 import { DashboardReportsController } from "./dashboard-reports.controller";
@@ -24,6 +25,32 @@ const newSignupsDashboard: NewSignupsDashboardDto = {
     peakMonth: "2026-02-01",
     peakMonthSignups: 12,
   },
+};
+
+const memberPaymentByCustomerDashboard: MemberPaymentByCustomerDashboardDto = {
+  dashboard: DashboardSlug.MemberPaymentByCustomer,
+  ...query,
+  series: [
+    {
+      key: "customer-client-a",
+      label: "Customer A",
+      customerId: "client-a",
+    },
+    {
+      key: "other-customers",
+      label: "Other Customers",
+      customerId: null,
+    },
+  ],
+  months: [
+    {
+      month: "2026-02-01",
+      values: {
+        "customer-client-a": 5000,
+        "other-customers": 1000,
+      },
+    },
+  ],
 };
 
 describe("DashboardReportsController", () => {
@@ -53,6 +80,8 @@ describe("DashboardReportsController", () => {
       newSignups: newSignupsDashboard,
       membersPaid: {},
       challengeParticipation: {},
+      memberPaymentByMonth: {},
+      memberPaymentByCustomer: memberPaymentByCustomerDashboard,
     };
     service.getAllDashboards.mockResolvedValue(response);
 
@@ -61,13 +90,13 @@ describe("DashboardReportsController", () => {
   });
 
   it("delegates a selected detail dashboard", async () => {
-    service.getDashboard.mockResolvedValue(newSignupsDashboard);
+    service.getDashboard.mockResolvedValue(memberPaymentByCustomerDashboard);
 
     await expect(
-      controller.getDashboard(DashboardSlug.NewSignups, query),
-    ).resolves.toBe(newSignupsDashboard);
+      controller.getDashboard(DashboardSlug.MemberPaymentByCustomer, query),
+    ).resolves.toBe(memberPaymentByCustomerDashboard);
     expect(service.getDashboard).toHaveBeenCalledWith(
-      DashboardSlug.NewSignups,
+      DashboardSlug.MemberPaymentByCustomer,
       query,
     );
   });
@@ -88,14 +117,30 @@ describe("DashboardReportsController", () => {
         challenge: 5,
         engagement: 2,
       },
+      {
+        dashboard: DashboardSlug.MemberPaymentByMonth,
+        month: "2026-02-01",
+        taas: 1000,
+        task: 2000,
+        challenge: 3000,
+        engagement: 4000,
+      },
+      {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        month: "2026-02-01",
+        customer: "Customer A",
+        amount: 5000,
+      },
     ];
     service.exportAllDashboards.mockResolvedValue(rows);
 
     await expect(controller.exportAllDashboards(query)).resolves.toBe(
       [
-        "dashboard,month,activated,notActivated,taas,task,challenge,engagement",
-        "new-signups,2026-02-01,10,2,,,,",
-        "members-paid,2026-02-01,,,3,4,5,2",
+        "dashboard,month,activated,notActivated,taas,task,challenge,engagement,customer,amount",
+        "new-signups,2026-02-01,10,2,,,,,,",
+        "members-paid,2026-02-01,,,3,4,5,2,,",
+        "member-payment-by-month,2026-02-01,,,1000,2000,3000,4000,,",
+        "member-payment-by-customer,2026-02-01,,,,,,,Customer A,5000",
       ].join("\n"),
     );
     expect(service.exportAllDashboards).toHaveBeenCalledWith(query);
@@ -104,21 +149,28 @@ describe("DashboardReportsController", () => {
   it("serializes one selected dashboard as CSV", async () => {
     service.exportDashboard.mockResolvedValue([
       {
-        dashboard: DashboardSlug.ChallengeParticipation,
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
         month: "2026-02-01",
-        registrants: 12,
-        submitters: 9,
+        customer: "Customer A",
+        amount: 5000,
+      },
+      {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        month: "2026-02-01",
+        customer: "Other Customers",
+        amount: 1000,
       },
     ]);
 
     await expect(
-      controller.exportDashboard(DashboardSlug.ChallengeParticipation, query),
+      controller.exportDashboard(DashboardSlug.MemberPaymentByCustomer, query),
     ).resolves.toBe(
-      "dashboard,month,registrants,submitters\n" +
-        "challenge-participation,2026-02-01,12,9",
+      "dashboard,month,customer,amount\n" +
+        "member-payment-by-customer,2026-02-01,Customer A,5000\n" +
+        "member-payment-by-customer,2026-02-01,Other Customers,1000",
     );
     expect(service.exportDashboard).toHaveBeenCalledWith(
-      DashboardSlug.ChallengeParticipation,
+      DashboardSlug.MemberPaymentByCustomer,
       query,
     );
   });

--- a/src/reports/dashboard/dashboard-reports.controller.ts
+++ b/src/reports/dashboard/dashboard-reports.controller.ts
@@ -27,6 +27,8 @@ import {
   DashboardQueryDto,
   DashboardResponse,
   DashboardSlug,
+  MemberPaymentByCustomerDashboardDto,
+  MemberPaymentByMonthDashboardDto,
   MembersPaidDashboardDto,
   NewSignupsDashboardDto,
 } from "./dashboard-reports.dto";
@@ -42,6 +44,8 @@ import { DashboardReportsGuard } from "./guards/dashboard-reports.guard";
   NewSignupsDashboardDto,
   MembersPaidDashboardDto,
   ChallengeParticipationDashboardDto,
+  MemberPaymentByMonthDashboardDto,
+  MemberPaymentByCustomerDashboardDto,
 )
 @ApiUnauthorizedResponse({ description: "Unauthenticated." })
 @ApiForbiddenResponse({
@@ -66,14 +70,14 @@ export class DashboardReportsController {
    * Retrieves all dashboards for the landing page.
    *
    * @param query Optional half-open reporting range.
-   * @returns All three complete dashboard responses.
+   * @returns All five complete dashboard responses.
    * @throws BadRequestException when the range is invalid.
    */
   @Get()
   @ApiOperation({
     summary: "Get all Reports Portal dashboards",
     description:
-      "Returns monthly data for new signups, unique paid members, and challenge participation. The default range is the latest six UTC calendar months; summary metrics are all-time.",
+      "Returns monthly data for new signups, unique paid members, challenge participation, member-payment values by type, and member-payment values by customer. The default range is the latest six UTC calendar months; summary metrics on the original dashboards are all-time.",
   })
   @ApiOkResponse({ type: AllDashboardsDto })
   @ApiBadRequestResponse({ description: "Invalid reporting date range." })
@@ -94,7 +98,7 @@ export class DashboardReportsController {
   @ApiOperation({ summary: "Export all dashboard month data as CSV" })
   @ApiProduces("text/csv")
   @ApiOkResponse({
-    description: "Flat CSV rows for all three dashboards.",
+    description: "Flat CSV rows for all five dashboards.",
     type: String,
   })
   @ApiBadRequestResponse({ description: "Invalid reporting date range." })
@@ -154,6 +158,8 @@ export class DashboardReportsController {
         { $ref: getSchemaPath(NewSignupsDashboardDto) },
         { $ref: getSchemaPath(MembersPaidDashboardDto) },
         { $ref: getSchemaPath(ChallengeParticipationDashboardDto) },
+        { $ref: getSchemaPath(MemberPaymentByMonthDashboardDto) },
+        { $ref: getSchemaPath(MemberPaymentByCustomerDashboardDto) },
       ],
     },
   })

--- a/src/reports/dashboard/dashboard-reports.dto.ts
+++ b/src/reports/dashboard/dashboard-reports.dto.ts
@@ -8,6 +8,8 @@ export enum DashboardSlug {
   NewSignups = "new-signups",
   MembersPaid = "members-paid",
   ChallengeParticipation = "challenge-participation",
+  MemberPaymentByMonth = "member-payment-by-month",
+  MemberPaymentByCustomer = "member-payment-by-customer",
 }
 
 /**
@@ -242,7 +244,116 @@ export class ChallengeParticipationDashboardDto {
 }
 
 /**
- * Aggregate landing-page response containing all three full dashboards.
+ * One month of member-payment values split by canonical payment type.
+ */
+export class MemberPaymentMonthDto {
+  @ApiProperty({ example: "2026-02-01" })
+  month: string;
+
+  @ApiProperty({ example: 185250.5 })
+  taas: number;
+
+  @ApiProperty({ example: 92340 })
+  task: number;
+
+  @ApiProperty({ example: 246100.75 })
+  challenge: number;
+
+  @ApiProperty({ example: 63400 })
+  engagement: number;
+}
+
+/**
+ * Monthly member-payment values split by canonical payment type.
+ */
+export class MemberPaymentByMonthDashboardDto {
+  @ApiProperty({
+    enum: [DashboardSlug.MemberPaymentByMonth],
+    example: DashboardSlug.MemberPaymentByMonth,
+  })
+  dashboard: DashboardSlug.MemberPaymentByMonth;
+
+  @ApiProperty({ example: "2026-02-01T00:00:00.000Z" })
+  startDate: string;
+
+  @ApiProperty({
+    description: "Exclusive reporting range end.",
+    example: "2026-08-01T00:00:00.000Z",
+  })
+  endDate: string;
+
+  @ApiProperty({ type: [MemberPaymentMonthDto] })
+  months: MemberPaymentMonthDto[];
+}
+
+/**
+ * One customer series used by the monthly member-payment chart.
+ */
+export class MemberPaymentCustomerSeriesDto {
+  @ApiProperty({
+    description: "Stable API-generated key used in each month's values map.",
+    example: "customer-client-123",
+  })
+  key: string;
+
+  @ApiProperty({ example: "Example Customer" })
+  label: string;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      "Billing-account client identifier, or null for Other Customers.",
+    example: "client-123",
+  })
+  customerId: string | null;
+}
+
+/**
+ * One month of member-payment values keyed by customer-series key.
+ */
+export class MemberPaymentByCustomerMonthDto {
+  @ApiProperty({ example: "2026-02-01" })
+  month: string;
+
+  @ApiProperty({
+    type: "object",
+    additionalProperties: { type: "number" },
+    example: {
+      "customer-client-123": 185250.5,
+      "other-customers": 92340,
+    },
+  })
+  values: Record<string, number>;
+}
+
+/**
+ * Monthly member-payment values split by the range's top customers.
+ */
+export class MemberPaymentByCustomerDashboardDto {
+  @ApiProperty({
+    enum: [DashboardSlug.MemberPaymentByCustomer],
+    example: DashboardSlug.MemberPaymentByCustomer,
+  })
+  dashboard: DashboardSlug.MemberPaymentByCustomer;
+
+  @ApiProperty({ example: "2026-02-01T00:00:00.000Z" })
+  startDate: string;
+
+  @ApiProperty({
+    description: "Exclusive reporting range end.",
+    example: "2026-08-01T00:00:00.000Z",
+  })
+  endDate: string;
+
+  @ApiProperty({ type: [MemberPaymentCustomerSeriesDto] })
+  series: MemberPaymentCustomerSeriesDto[];
+
+  @ApiProperty({ type: [MemberPaymentByCustomerMonthDto] })
+  months: MemberPaymentByCustomerMonthDto[];
+}
+
+/**
+ * Aggregate landing-page response containing all five full dashboards.
  */
 export class AllDashboardsDto {
   @ApiProperty({ type: NewSignupsDashboardDto })
@@ -253,6 +364,12 @@ export class AllDashboardsDto {
 
   @ApiProperty({ type: ChallengeParticipationDashboardDto })
   challengeParticipation: ChallengeParticipationDashboardDto;
+
+  @ApiProperty({ type: MemberPaymentByMonthDashboardDto })
+  memberPaymentByMonth: MemberPaymentByMonthDashboardDto;
+
+  @ApiProperty({ type: MemberPaymentByCustomerDashboardDto })
+  memberPaymentByCustomer: MemberPaymentByCustomerDashboardDto;
 }
 
 /**
@@ -291,6 +408,12 @@ export class DashboardExportRowDto {
 
   @ApiPropertyOptional()
   submitters?: number;
+
+  @ApiPropertyOptional()
+  customer?: string;
+
+  @ApiPropertyOptional()
+  amount?: number;
 }
 
 /**
@@ -299,4 +422,6 @@ export class DashboardExportRowDto {
 export type DashboardResponse =
   | NewSignupsDashboardDto
   | MembersPaidDashboardDto
-  | ChallengeParticipationDashboardDto;
+  | ChallengeParticipationDashboardDto
+  | MemberPaymentByMonthDashboardDto
+  | MemberPaymentByCustomerDashboardDto;

--- a/src/reports/dashboard/dashboard-reports.service.spec.ts
+++ b/src/reports/dashboard/dashboard-reports.service.spec.ts
@@ -4,6 +4,8 @@ import { DbService } from "../../db/db.service";
 import {
   ChallengeParticipationDashboardDto,
   DashboardSlug,
+  MemberPaymentByCustomerDashboardDto,
+  MemberPaymentByMonthDashboardDto,
   MembersPaidDashboardDto,
   NewSignupsDashboardDto,
 } from "./dashboard-reports.dto";
@@ -69,6 +71,47 @@ const challengeParticipationRows = [
     submission_rate: "75.0",
     peak_month: "2025-10-01",
     peak_month_registrants: "18",
+  },
+];
+
+const memberPaymentByMonthRows = [
+  {
+    month: "2026-02-01",
+    taas: "1250.50",
+    task: "2400",
+    challenge: "3750.25",
+    engagement: "900",
+  },
+  {
+    month: "2026-03-01",
+    taas: "1500",
+    task: "2100.75",
+    challenge: "4200",
+    engagement: "1100",
+  },
+];
+
+const memberPaymentByCustomerRows = [
+  {
+    month: "2026-02-01",
+    series_key: "customer-client-a",
+    customer_id: "client-a",
+    customer_label: "Customer A",
+    amount: "5000.25",
+  },
+  {
+    month: "2026-02-01",
+    series_key: "other-customers",
+    customer_id: null,
+    customer_label: "Other Customers",
+    amount: "1200",
+  },
+  {
+    month: "2026-03-01",
+    series_key: "customer-client-a",
+    customer_id: "client-a",
+    customer_label: "Customer A",
+    amount: "6200",
   },
 ];
 
@@ -145,6 +188,10 @@ describe("DashboardReportsService", () => {
             return Promise.resolve(membersPaidRows);
           case "reports/dashboard/challenge-participation.sql":
             return Promise.resolve(challengeParticipationRows);
+          case "reports/dashboard/member-payment-by-month.sql":
+            return Promise.resolve(memberPaymentByMonthRows);
+          case "reports/dashboard/member-payment-by-customer.sql":
+            return Promise.resolve(memberPaymentByCustomerRows);
           default:
             return Promise.resolve([]);
         }
@@ -222,14 +269,68 @@ describe("DashboardReportsService", () => {
           peakMonthRegistrants: 18,
         },
       },
+      memberPaymentByMonth: {
+        dashboard: DashboardSlug.MemberPaymentByMonth,
+        ...rangeQuery,
+        months: [
+          {
+            month: "2026-02-01",
+            taas: 1250.5,
+            task: 2400,
+            challenge: 3750.25,
+            engagement: 900,
+          },
+          {
+            month: "2026-03-01",
+            taas: 1500,
+            task: 2100.75,
+            challenge: 4200,
+            engagement: 1100,
+          },
+        ],
+      },
+      memberPaymentByCustomer: {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        ...rangeQuery,
+        series: [
+          {
+            key: "customer-client-a",
+            label: "Customer A",
+            customerId: "client-a",
+          },
+          {
+            key: "other-customers",
+            label: "Other Customers",
+            customerId: null,
+          },
+        ],
+        months: [
+          {
+            month: "2026-02-01",
+            values: {
+              "customer-client-a": 5000.25,
+              "other-customers": 1200,
+            },
+          },
+          {
+            month: "2026-03-01",
+            values: {
+              "customer-client-a": 6200,
+              "other-customers": 0,
+            },
+          },
+        ],
+      },
     });
 
     expect(sql.load.mock.calls).toEqual([
       ["reports/dashboard/new-signups.sql"],
       ["reports/dashboard/members-paid.sql"],
       ["reports/dashboard/challenge-participation.sql"],
+      ["reports/dashboard/member-payment-by-month.sql"],
+      ["reports/dashboard/member-payment-by-customer.sql"],
     ]);
-    expect(db.query).toHaveBeenCalledTimes(3);
+    expect(db.query).toHaveBeenCalledTimes(5);
     expect(db.query).toHaveBeenCalledWith("reports/dashboard/new-signups.sql", [
       rangeQuery.startDate,
       rangeQuery.endDate,
@@ -238,13 +339,15 @@ describe("DashboardReportsService", () => {
 
   it("loads only the requested detail dashboard", async () => {
     const result = await service.getDashboard(
-      DashboardSlug.MembersPaid,
+      DashboardSlug.MemberPaymentByCustomer,
       rangeQuery,
     );
 
-    expect(result.dashboard).toBe(DashboardSlug.MembersPaid);
+    expect(result.dashboard).toBe(DashboardSlug.MemberPaymentByCustomer);
     expect(sql.load).toHaveBeenCalledTimes(1);
-    expect(sql.load).toHaveBeenCalledWith("reports/dashboard/members-paid.sql");
+    expect(sql.load).toHaveBeenCalledWith(
+      "reports/dashboard/member-payment-by-customer.sql",
+    );
   });
 
   it("rejects an unsupported dashboard discriminator", async () => {
@@ -322,6 +425,44 @@ describe("DashboardReportsService", () => {
           peakMonthRegistrants: 12,
         },
       } satisfies ChallengeParticipationDashboardDto,
+      memberPaymentByMonth: {
+        dashboard: DashboardSlug.MemberPaymentByMonth,
+        ...rangeQuery,
+        months: [
+          {
+            month: "2026-02-01",
+            taas: 1000,
+            task: 2000,
+            challenge: 3000,
+            engagement: 4000,
+          },
+        ],
+      } satisfies MemberPaymentByMonthDashboardDto,
+      memberPaymentByCustomer: {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        ...rangeQuery,
+        series: [
+          {
+            key: "customer-client-a",
+            label: "Customer A",
+            customerId: "client-a",
+          },
+          {
+            key: "other-customers",
+            label: "Other Customers",
+            customerId: null,
+          },
+        ],
+        months: [
+          {
+            month: "2026-02-01",
+            values: {
+              "customer-client-a": 6500,
+              "other-customers": 3500,
+            },
+          },
+        ],
+      } satisfies MemberPaymentByCustomerDashboardDto,
     };
     jest.spyOn(service, "getAllDashboards").mockResolvedValue(dashboards);
 
@@ -345,6 +486,26 @@ describe("DashboardReportsService", () => {
         month: "2026-02-01",
         registrants: 12,
         submitters: 9,
+      },
+      {
+        dashboard: DashboardSlug.MemberPaymentByMonth,
+        month: "2026-02-01",
+        taas: 1000,
+        task: 2000,
+        challenge: 3000,
+        engagement: 4000,
+      },
+      {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        month: "2026-02-01",
+        customer: "Customer A",
+        amount: 6500,
+      },
+      {
+        dashboard: DashboardSlug.MemberPaymentByCustomer,
+        month: "2026-02-01",
+        customer: "Other Customers",
+        amount: 3500,
       },
     ]);
   });

--- a/src/reports/dashboard/dashboard-reports.service.ts
+++ b/src/reports/dashboard/dashboard-reports.service.ts
@@ -8,6 +8,8 @@ import {
   DashboardQueryDto,
   DashboardResponse,
   DashboardSlug,
+  MemberPaymentByCustomerDashboardDto,
+  MemberPaymentByMonthDashboardDto,
   MembersPaidDashboardDto,
   NewSignupsDashboardDto,
 } from "./dashboard-reports.dto";
@@ -50,6 +52,22 @@ type ChallengeParticipationRow = {
   submission_rate: QueryValue;
   peak_month: string | null;
   peak_month_registrants: QueryValue;
+};
+
+type MemberPaymentByMonthRow = {
+  month: string;
+  taas: QueryValue;
+  task: QueryValue;
+  challenge: QueryValue;
+  engagement: QueryValue;
+};
+
+type MemberPaymentByCustomerRow = {
+  month: string;
+  series_key: string;
+  customer_id: string | null;
+  customer_label: string;
+  amount: QueryValue;
 };
 
 /**
@@ -185,7 +203,7 @@ export class DashboardReportsService {
   ) {}
 
   /**
-   * Loads all three dashboards for one shared reporting range.
+   * Loads all five dashboards for one shared reporting range.
    *
    * @param query Optional date range.
    * @returns Full dashboard objects keyed for the landing page.
@@ -193,18 +211,26 @@ export class DashboardReportsService {
    */
   async getAllDashboards(query: DashboardQueryDto): Promise<AllDashboardsDto> {
     const range = resolveDashboardDateRange(query);
-    const [newSignups, membersPaid, challengeParticipation] = await Promise.all(
-      [
-        this.loadNewSignups(range),
-        this.loadMembersPaid(range),
-        this.loadChallengeParticipation(range),
-      ],
-    );
+    const [
+      newSignups,
+      membersPaid,
+      challengeParticipation,
+      memberPaymentByMonth,
+      memberPaymentByCustomer,
+    ] = await Promise.all([
+      this.loadNewSignups(range),
+      this.loadMembersPaid(range),
+      this.loadChallengeParticipation(range),
+      this.loadMemberPaymentByMonth(range),
+      this.loadMemberPaymentByCustomer(range),
+    ]);
 
     return {
       newSignups,
       membersPaid,
       challengeParticipation,
+      memberPaymentByMonth,
+      memberPaymentByCustomer,
     };
   }
 
@@ -229,6 +255,10 @@ export class DashboardReportsService {
         return this.loadMembersPaid(range);
       case DashboardSlug.ChallengeParticipation:
         return this.loadChallengeParticipation(range);
+      case DashboardSlug.MemberPaymentByMonth:
+        return this.loadMemberPaymentByMonth(range);
+      case DashboardSlug.MemberPaymentByCustomer:
+        return this.loadMemberPaymentByCustomer(range);
       default:
         throw new BadRequestException("Unsupported dashboard.");
     }
@@ -249,6 +279,8 @@ export class DashboardReportsService {
       ...this.toExportRows(dashboards.newSignups),
       ...this.toExportRows(dashboards.membersPaid),
       ...this.toExportRows(dashboards.challengeParticipation),
+      ...this.toExportRows(dashboards.memberPaymentByMonth),
+      ...this.toExportRows(dashboards.memberPaymentByCustomer),
     ];
   }
 
@@ -378,6 +410,87 @@ export class DashboardReportsService {
   }
 
   /**
+   * Executes and maps the monthly member-payment value SQL.
+   *
+   * @param range Explicit half-open query range.
+   * @returns Monthly member-payment values split by canonical payment type.
+   */
+  private async loadMemberPaymentByMonth(
+    range: DashboardDateRange,
+  ): Promise<MemberPaymentByMonthDashboardDto> {
+    const query = this.sql.load(
+      "reports/dashboard/member-payment-by-month.sql",
+    );
+    const rows = await this.db.query<MemberPaymentByMonthRow>(query, [
+      range.startDate,
+      range.endDate,
+    ]);
+
+    return {
+      dashboard: DashboardSlug.MemberPaymentByMonth,
+      ...range,
+      months: rows.map((row) => ({
+        month: row.month,
+        taas: toNumber(row.taas),
+        task: toNumber(row.task),
+        challenge: toNumber(row.challenge),
+        engagement: toNumber(row.engagement),
+      })),
+    };
+  }
+
+  /**
+   * Executes and maps the monthly member-payment-by-customer SQL.
+   *
+   * @param range Explicit half-open query range.
+   * @returns Stable customer series and zero-filled monthly value maps.
+   */
+  private async loadMemberPaymentByCustomer(
+    range: DashboardDateRange,
+  ): Promise<MemberPaymentByCustomerDashboardDto> {
+    const query = this.sql.load(
+      "reports/dashboard/member-payment-by-customer.sql",
+    );
+    const rows = await this.db.query<MemberPaymentByCustomerRow>(query, [
+      range.startDate,
+      range.endDate,
+    ]);
+    const seriesByKey = new Map<
+      string,
+      MemberPaymentByCustomerDashboardDto["series"][number]
+    >();
+    const monthValues = new Map<string, Map<string, number>>();
+
+    for (const row of rows) {
+      if (!seriesByKey.has(row.series_key)) {
+        seriesByKey.set(row.series_key, {
+          key: row.series_key,
+          label: row.customer_label,
+          customerId: row.customer_id,
+        });
+      }
+
+      const values = monthValues.get(row.month) ?? new Map<string, number>();
+      values.set(row.series_key, toNumber(row.amount));
+      monthValues.set(row.month, values);
+    }
+
+    const series = [...seriesByKey.values()];
+
+    return {
+      dashboard: DashboardSlug.MemberPaymentByCustomer,
+      ...range,
+      series,
+      months: [...monthValues].map(([month, values]) => ({
+        month,
+        values: Object.fromEntries(
+          series.map(({ key }) => [key, values.get(key) ?? 0]),
+        ),
+      })),
+    };
+  }
+
+  /**
    * Flattens a dashboard response into monthly CSV rows.
    *
    * @param dashboard Full dashboard response.
@@ -408,6 +521,24 @@ export class DashboardReportsService {
           registrants: month.registrants,
           submitters: month.submitters,
         }));
+      case DashboardSlug.MemberPaymentByMonth:
+        return dashboard.months.map((month) => ({
+          dashboard: dashboard.dashboard,
+          month: month.month,
+          taas: month.taas,
+          task: month.task,
+          challenge: month.challenge,
+          engagement: month.engagement,
+        }));
+      case DashboardSlug.MemberPaymentByCustomer:
+        return dashboard.months.flatMap((month) =>
+          dashboard.series.map((series) => ({
+            dashboard: dashboard.dashboard,
+            month: month.month,
+            customer: series.label,
+            amount: month.values[series.key] ?? 0,
+          })),
+        );
     }
   }
 }

--- a/src/reports/dashboard/dashboard-reports.sql.spec.ts
+++ b/src/reports/dashboard/dashboard-reports.sql.spec.ts
@@ -7,6 +7,8 @@ describe("Dashboard report SQL", () => {
     "new-signups.sql",
     "members-paid.sql",
     "challenge-participation.sql",
+    "member-payment-by-month.sql",
+    "member-payment-by-customer.sql",
   ])(
     "uses a half-open range and emits zero-filled calendar months: %s",
     (file) => {
@@ -46,6 +48,60 @@ describe("Dashboard report SQL", () => {
       "w.category::text IS DISTINCT FROM 'TOPGEAR_PAYMENT'",
     );
     expect(sql).toMatch(/COUNT\(DISTINCT pe\.member_id\) FILTER/g);
+  });
+
+  it("sums latest paid-member values by canonical payment bucket", () => {
+    const sql = sqlLoader.load("reports/dashboard/member-payment-by-month.sql");
+
+    expect(sql).toContain("MAX(p.version) AS max_version");
+    expect(sql).toContain("lpv.max_version = p.version");
+    expect(sql).toContain("p.payment_status = 'PAID'");
+    expect(sql).toContain("w.type = 'PAYMENT'");
+    expect(sql).toContain("COALESCE(p.date_paid, p.created_at)");
+    expect(sql).toContain(
+      "COALESCE(p.gross_amount, p.total_amount, 0) AS amount",
+    );
+    expect(sql).toContain("w.category::text = 'TAAS_PAYMENT'");
+    expect(sql).toContain("w.category::text = 'ENGAGEMENT_PAYMENT'");
+    expect(sql).toContain("'TASK_REVIEW_PAYMENT'");
+    expect(sql).toContain(
+      "w.category::text IS DISTINCT FROM 'TOPGEAR_PAYMENT'",
+    );
+    expect(sql).toMatch(/SUM\(pe\.amount\) FILTER/g);
+  });
+
+  it("ranks five clients once and zero-fills an Other Customers series", () => {
+    const sql = sqlLoader.load(
+      "reports/dashboard/member-payment-by-customer.sql",
+    );
+
+    expect(sql).toContain("MAX(p.version) AS max_version");
+    expect(sql).toContain("p.payment_status = 'PAID'");
+    expect(sql).toContain(
+      "COALESCE(p.gross_amount, p.total_amount, 0) AS amount",
+    );
+    expect(sql).toContain('LEFT JOIN challenges."ChallengeBilling" cb');
+    expect(sql).toContain(
+      'LEFT JOIN "billing-accounts"."BillingAccount" payment_ba',
+    );
+    expect(sql).toContain(
+      'LEFT JOIN "billing-accounts"."BillingAccount" challenge_ba',
+    );
+    expect(sql).toContain('LEFT JOIN "billing-accounts"."Client" cl');
+    expect(sql).toContain("payment_ba.id::text");
+    expect(sql).toContain("challenge_ba.id::text");
+    expect(sql).toContain("TRIM(LEADING '0'");
+    expect(sql).toContain(
+      'COALESCE(payment_ba."clientId", challenge_ba."clientId")',
+    );
+    expect(sql).not.toContain("::integer");
+    expect(sql).toContain("ROW_NUMBER() OVER");
+    expect(sql).toContain("ct.total_amount DESC");
+    expect(sql).toContain("WHERE rc.series_order <= 5");
+    expect(sql).toContain("'other-customers' AS series_key");
+    expect(sql).toContain("'Other Customers' AS customer_label");
+    expect(sql).toContain("CROSS JOIN series s");
+    expect(sql).toContain("COALESCE(ma.amount, 0) AS amount");
   });
 
   it("counts registration and submission activity independently", () => {


### PR DESCRIPTION
## What was broken

The Reports Portal API returned only the original dashboards, so it could not supply monthly member payment values by type or by customer.

## Root cause

There were no dashboard SQL queries, DTOs, service mappings, or export paths for the two member payment datasets.

## What was changed

- Added zero-filled monthly member payment totals split across TAAS, Task, Contest, and Engagement buckets.
- Added the selected range's top five clients as stable series and grouped remaining or unnamed clients under Other Customers.
- Added both datasets to aggregate, detail, and CSV endpoints with Swagger metadata and README documentation.
- Reused the existing paid-event, latest-version, member-amount, customer, and half-open UTC range conventions.

## Any added/updated tests

- Added SQL structure coverage for payment categorization, latest versions, customer joins/ranking, and Other Customers.
- Updated service and controller coverage for numeric mapping, zero filling, aggregate/detail responses, and CSV exports.
- PM-5719 focused tests pass: 5 suites and 35 tests.
- `pnpm lint` and `pnpm build` pass. The full repository suite was also run; 3 unrelated SFDC/report-directory suites fail on unchanged code paths, while 19 suites and 338 tests pass.
