### PR TITLE
PM-4620 general statistics

### DIFF
--- a/sql/reports/statistics/general/country-member-details.sql
+++ b/sql/reports/statistics/general/country-member-details.sql
@@ -1,0 +1,127 @@
+WITH member_profiles AS (
+  SELECT
+    m."userId" AS user_id,
+    COALESCE(
+      NULLIF(TRIM(m."competitionCountryCode"), ''),
+      NULLIF(TRIM(m."homeCountryCode"), '')
+    ) AS country_code,
+    m.handle,
+    m."photoURL" AS photo_url
+  FROM members.member m
+),
+country_members AS (
+  SELECT
+    country_code,
+    COUNT(*)::bigint AS members_count
+  FROM member_profiles
+  WHERE country_code IS NOT NULL
+  GROUP BY country_code
+),
+country_skill_counts AS (
+  SELECT
+    members.country_code,
+    skill.id AS skill_id,
+    skill.name,
+    COUNT(DISTINCT user_skill.user_id)::bigint AS member_count
+  FROM member_profiles members
+  JOIN skills.user_skill user_skill
+    ON user_skill.user_id::bigint = members.user_id
+  JOIN skills.skill skill
+    ON skill.id = user_skill.skill_id
+   AND skill.deleted_at IS NULL
+  WHERE members.country_code IS NOT NULL
+  GROUP BY members.country_code, skill.id, skill.name
+),
+country_skills AS (
+  SELECT
+    country_code,
+    JSONB_AGG(
+      JSONB_BUILD_OBJECT(
+        'name', name,
+        'count', member_count
+      )
+      ORDER BY member_count DESC, name ASC, skill_id ASC
+    ) AS skills
+  FROM country_skill_counts
+  GROUP BY country_code
+),
+history_wins AS (
+  SELECT
+    history."userId",
+    history."trackId",
+    history."typeId",
+    COUNT(*)::bigint AS wins
+  FROM members."memberStatsHistory" history
+  WHERE history.placement = 1
+  GROUP BY history."userId", history."trackId", history."typeId"
+),
+stats_wins AS (
+  SELECT
+    stats."userId",
+    SUM(COALESCE(stats.wins, history.wins, 0))::bigint AS wins
+  FROM members."memberStats" stats
+  LEFT JOIN history_wins history
+    ON history."userId" = stats."userId"
+   AND history."trackId" = stats."trackId"
+   AND history."typeId" = stats."typeId"
+  LEFT JOIN challenges."ChallengeTrack" track
+    ON track.id::text = stats."trackId"
+  WHERE stats."isPrivate" = false
+    AND (
+      UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DESIGN%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DATA%SCIENCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) = 'QA'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
+    )
+  GROUP BY stats."userId"
+),
+winner_counts AS (
+  SELECT
+    members.country_code,
+    members.user_id,
+    members.handle,
+    members.photo_url,
+    rating.rating AS max_rating,
+    wins.wins
+  FROM stats_wins wins
+  JOIN member_profiles members
+    ON members.user_id = wins."userId"
+  LEFT JOIN members."memberMaxRating" rating
+    ON rating."userId" = members.user_id
+  WHERE members.country_code IS NOT NULL
+    AND NULLIF(TRIM(members.handle), '') IS NOT NULL
+    AND wins.wins > 0
+),
+top_members AS (
+  SELECT
+    country_code,
+    JSONB_BUILD_OBJECT(
+      'handle', handle,
+      'wins', wins,
+      'photoURL', photo_url,
+      'maxRating', max_rating
+    ) AS top_member
+  FROM (
+    SELECT
+      winner_counts.*,
+      ROW_NUMBER() OVER (
+        PARTITION BY country_code
+        ORDER BY wins DESC, handle ASC, user_id ASC
+      ) AS member_rank
+    FROM winner_counts
+  ) ranked_members
+  WHERE member_rank = 1
+)
+SELECT
+  countries.country_code,
+  countries.members_count AS "user.count",
+  COALESCE(skills.skills, '[]'::jsonb) AS skills,
+  members.top_member
+FROM country_members countries
+LEFT JOIN country_skills skills
+  ON skills.country_code = countries.country_code
+LEFT JOIN top_members members
+  ON members.country_code = countries.country_code
+ORDER BY "user.count" DESC, country_code ASC;

--- a/sql/reports/statistics/general/country-member-details.sql
+++ b/sql/reports/statistics/general/country-member-details.sql
@@ -17,20 +17,31 @@ country_members AS (
   WHERE country_code IS NOT NULL
   GROUP BY country_code
 ),
-country_skill_counts AS (
-  SELECT
+country_member_skills AS (
+  SELECT DISTINCT
     members.country_code,
+    members.user_id,
     skill.id AS skill_id,
-    skill.name,
-    COUNT(DISTINCT user_skill.user_id)::bigint AS member_count
+    skill.name
   FROM member_profiles members
   JOIN skills.user_skill user_skill
     ON user_skill.user_id::bigint = members.user_id
+  JOIN skills.user_skill_level skill_level
+    ON skill_level.id = user_skill.user_skill_level_id
+   AND LOWER(skill_level.name) IN ('verified', 'self-declared')
   JOIN skills.skill skill
     ON skill.id = user_skill.skill_id
    AND skill.deleted_at IS NULL
   WHERE members.country_code IS NOT NULL
-  GROUP BY members.country_code, skill.id, skill.name
+),
+country_skill_counts AS (
+  SELECT
+    owned.country_code,
+    owned.skill_id,
+    owned.name,
+    COUNT(*)::bigint AS owned_count
+  FROM country_member_skills owned
+  GROUP BY owned.country_code, owned.skill_id, owned.name
 ),
 country_skills AS (
   SELECT
@@ -38,9 +49,10 @@ country_skills AS (
     JSONB_AGG(
       JSONB_BUILD_OBJECT(
         'name', name,
-        'count', member_count
+        'count', owned_count,
+        'ownedCount', owned_count
       )
-      ORDER BY member_count DESC, name ASC, skill_id ASC
+      ORDER BY owned_count DESC, name ASC, skill_id ASC
     ) AS skills
   FROM country_skill_counts
   GROUP BY country_code
@@ -94,31 +106,35 @@ winner_counts AS (
     AND NULLIF(TRIM(members.handle), '') IS NOT NULL
     AND wins.wins > 0
 ),
+ranked_members AS (
+  SELECT
+    winner_counts.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY country_code
+      ORDER BY wins DESC, handle ASC, user_id ASC
+    ) AS member_rank
+  FROM winner_counts
+),
 top_members AS (
   SELECT
     country_code,
-    JSONB_BUILD_OBJECT(
-      'handle', handle,
-      'wins', wins,
-      'photoURL', photo_url,
-      'maxRating', max_rating
-    ) AS top_member
-  FROM (
-    SELECT
-      winner_counts.*,
-      ROW_NUMBER() OVER (
-        PARTITION BY country_code
-        ORDER BY wins DESC, handle ASC, user_id ASC
-      ) AS member_rank
-    FROM winner_counts
-  ) ranked_members
-  WHERE member_rank = 1
+    JSONB_AGG(
+      JSONB_BUILD_OBJECT(
+        'handle', handle,
+        'wins', wins,
+        'photoURL', photo_url,
+        'maxRating', max_rating
+      )
+      ORDER BY member_rank
+    ) FILTER (WHERE member_rank <= 3) AS top_members
+  FROM ranked_members
+  GROUP BY country_code
 )
 SELECT
   countries.country_code,
   countries.members_count AS "user.count",
   COALESCE(skills.skills, '[]'::jsonb) AS skills,
-  members.top_member
+  COALESCE(members.top_members, '[]'::jsonb) AS top_members
 FROM country_members countries
 LEFT JOIN country_skills skills
   ON skills.country_code = countries.country_code

--- a/sql/reports/statistics/general/first-place-by-country.sql
+++ b/sql/reports/statistics/general/first-place-by-country.sql
@@ -1,16 +1,45 @@
-WITH winners AS (
-  SELECT s."memberId"::text AS member_id
-  FROM reviews.submission s
-  WHERE s.placement = 1
+WITH history_wins AS (
+  SELECT
+    history."userId",
+    history."trackId",
+    history."typeId",
+    COUNT(*)::bigint AS wins
+  FROM members."memberStatsHistory" history
+  WHERE history.placement = 1
+  GROUP BY history."userId", history."trackId", history."typeId"
+),
+member_wins AS (
+  SELECT
+    stats."userId",
+    SUM(COALESCE(stats.wins, history.wins, 0))::bigint AS wins
+  FROM members."memberStats" stats
+  LEFT JOIN history_wins history
+    ON history."userId" = stats."userId"
+   AND history."trackId" = stats."trackId"
+   AND history."typeId" = stats."typeId"
+  LEFT JOIN challenges."ChallengeTrack" track
+    ON track.id::text = stats."trackId"
+  WHERE stats."isPrivate" = false
+    AND (
+      UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DESIGN%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DATA%SCIENCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) = 'QA'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
+    )
+  GROUP BY stats."userId"
 ),
 winners_country AS (
   SELECT
     COALESCE(
-      NULLIF(TRIM(m."homeCountryCode"), ''),
-      NULLIF(TRIM(m."competitionCountryCode"), '')
-    ) AS country_code
-  FROM winners w
-  JOIN members.member m ON m."userId"::text = w.member_id
+      NULLIF(TRIM(m."competitionCountryCode"), ''),
+      NULLIF(TRIM(m."homeCountryCode"), '')
+    ) AS country_code,
+    w.wins
+  FROM member_wins w
+  JOIN members.member m ON m."userId" = w."userId"
+  WHERE w.wins > 0
 )
 SELECT
   country_code,
@@ -19,7 +48,7 @@ SELECT
 FROM (
   SELECT
     country_code,
-    COUNT(*)::bigint AS first_place_count
+    SUM(wins)::bigint AS first_place_count
   FROM winners_country
   WHERE country_code IS NOT NULL
   GROUP BY country_code

--- a/sql/reports/statistics/general/top-winners-by-country.sql
+++ b/sql/reports/statistics/general/top-winners-by-country.sql
@@ -1,0 +1,97 @@
+WITH history_wins AS (
+  SELECT
+    history."userId",
+    history."trackId",
+    history."typeId",
+    COUNT(*)::bigint AS wins
+  FROM members."memberStatsHistory" history
+  WHERE history.placement = 1
+  GROUP BY history."userId", history."trackId", history."typeId"
+),
+stats_wins AS (
+  SELECT
+    stats."userId",
+    SUM(COALESCE(stats.wins, history.wins, 0))::bigint AS wins
+  FROM members."memberStats" stats
+  LEFT JOIN history_wins history
+    ON history."userId" = stats."userId"
+   AND history."trackId" = stats."trackId"
+   AND history."typeId" = stats."typeId"
+  LEFT JOIN challenges."ChallengeTrack" track
+    ON track.id::text = stats."trackId"
+  WHERE stats."isPrivate" = false
+    AND (
+      UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DESIGN%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DATA%SCIENCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) = 'QA'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
+      OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
+    )
+  GROUP BY stats."userId"
+),
+winner_profiles AS (
+  SELECT
+    COALESCE(
+      NULLIF(TRIM(m."competitionCountryCode"), ''),
+      NULLIF(TRIM(m."homeCountryCode"), '')
+    ) AS country_code,
+    m."userId" AS user_id,
+    m.handle,
+    m."photoURL" AS photo_url,
+    mmr.rating AS max_rating,
+    wins.wins
+  FROM stats_wins wins
+  JOIN members.member m
+    ON m."userId" = wins."userId"
+  LEFT JOIN members."memberMaxRating" mmr
+    ON mmr."userId" = m."userId"
+  WHERE COALESCE(
+    NULLIF(TRIM(m."competitionCountryCode"), ''),
+    NULLIF(TRIM(m."homeCountryCode"), '')
+  ) IS NOT NULL
+    AND wins.wins > 0
+),
+country_totals AS (
+  SELECT
+    country_code,
+    SUM(wins)::bigint AS first_place_count
+  FROM winner_profiles
+  GROUP BY country_code
+),
+ranked_winners AS (
+  SELECT
+    winner_profiles.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY country_code
+      ORDER BY wins DESC, handle ASC, user_id ASC
+    ) AS winner_rank
+  FROM winner_profiles
+  WHERE NULLIF(TRIM(handle), '') IS NOT NULL
+),
+country_winners AS (
+  SELECT
+    country_code,
+    JSONB_AGG(
+      JSONB_BUILD_OBJECT(
+        'handle', handle,
+        'wins', wins,
+        'photoURL', photo_url,
+        'maxRating', max_rating
+      )
+      ORDER BY winner_rank
+    ) FILTER (WHERE winner_rank <= 3) AS top_winners
+  FROM ranked_winners
+  GROUP BY country_code
+)
+SELECT
+  totals.country_code,
+  totals.first_place_count AS "challenge_stats.count",
+  DENSE_RANK() OVER (
+    ORDER BY totals.first_place_count DESC, totals.country_code ASC
+  )::int AS rank,
+  COALESCE(winners.top_winners, '[]'::jsonb) AS top_winners
+FROM country_totals totals
+LEFT JOIN country_winners winners
+  ON winners.country_code = totals.country_code
+ORDER BY "challenge_stats.count" DESC, country_code ASC;

--- a/src/reports/report-directory.data.spec.ts
+++ b/src/reports/report-directory.data.spec.ts
@@ -19,6 +19,12 @@ describe("getAccessibleReportsDirectory", () => {
       "/payment/member-payment-accrual-task",
       "/payment/member-payment-accrual-challenge",
     ]);
+    expect(directory.statistics?.reports.map((report) => report.path)).toEqual(
+      expect.arrayContaining([
+        "/statistics/general/country-member-details",
+        "/statistics/general/top-winners-by-country",
+      ]),
+    );
   });
 
   it("returns public reports plus all challenge reports for product managers", () => {

--- a/src/reports/report-directory.data.ts
+++ b/src/reports/report-directory.data.ts
@@ -541,9 +541,19 @@ const REGISTERED_REPORTS_DIRECTORY: RegisteredReportsDirectory = {
         "Member count by country (desc)",
       ),
       publicReport(
+        "Country Member Details",
+        "/statistics/general/country-member-details",
+        "Member, skill, and top-member details by country (desc)",
+      ),
+      publicReport(
         "First Place by Country",
         "/statistics/general/first-place-by-country",
         "First place finishes by country (desc)",
+      ),
+      publicReport(
+        "Top Winners by Country",
+        "/statistics/general/top-winners-by-country",
+        "First place finishes and top three winners by country (desc)",
       ),
       publicReport(
         "Copiloted Challenges",

--- a/src/statistics/general-statistics.service.spec.ts
+++ b/src/statistics/general-statistics.service.spec.ts
@@ -92,31 +92,47 @@ describe("GeneralStatisticsService", () => {
       {
         country_code: "IND",
         "user.count": "730554",
-        top_member: {
-          handle: "top-member",
-          maxRating: "2200",
-          photoURL: null,
-          wins: "1768",
-        },
+        top_members: [
+          {
+            handle: "top-member",
+            maxRating: "2200",
+            photoURL: null,
+            wins: "1768",
+          },
+          {
+            handle: "third-member",
+            maxRating: null,
+            photoURL: null,
+            wins: "100",
+          },
+        ],
         skills: [
-          { count: "40", name: "JavaScript" },
-          { count: "30", name: "Python" },
-          { count: "15", name: "Swift" },
+          { count: "50", name: "JavaScript", ownedCount: "50" },
+          { count: "30", name: "Python", ownedCount: "30" },
+          { count: "20", name: "Swift", ownedCount: "20" },
         ],
       },
       {
         country_code: "IN",
         "user.count": "10",
-        top_member: {
-          handle: "higher-winner",
-          maxRating: "2400",
-          photoURL: "https://example.com/higher.png",
-          wins: "2000",
-        },
+        top_members: [
+          {
+            handle: "higher-winner",
+            maxRating: "2400",
+            photoURL: "https://example.com/higher.png",
+            wins: "2000",
+          },
+          {
+            handle: "second-member",
+            maxRating: "2300",
+            photoURL: null,
+            wins: "1800",
+          },
+        ],
         skills: [
-          { count: "10", name: "javascript" },
-          { count: "25", name: "Rust" },
-          { count: "20", name: "Go" },
+          { count: "10", name: "javascript", ownedCount: "10" },
+          { count: "25", name: "Rust", ownedCount: "25" },
+          { count: "15", name: "Go", ownedCount: "15" },
         ],
       },
     ]);
@@ -127,19 +143,36 @@ describe("GeneralStatisticsService", () => {
         "country.country_code": "IND",
         "user.count": 730564,
         rank: 1,
-        skillAssignments: 140,
-        topMember: {
-          handle: "higher-winner",
-          maxRating: 2400,
-          photoURL: "https://example.com/higher.png",
-          wins: 2000,
-        },
-        topSkills: [
-          { count: 50, name: "JavaScript" },
-          { count: 30, name: "Python" },
-          { count: 25, name: "Rust" },
+        skillsBreakdown: [
+          { count: 60, name: "JavaScript", percentage: 40 },
+          { count: 30, name: "Python", percentage: 20 },
+          {
+            count: 25,
+            name: "Rust",
+            percentage: 16.666666666666664,
+          },
         ],
         totalSkills: 5,
+        topMembers: [
+          {
+            handle: "higher-winner",
+            maxRating: 2400,
+            photoURL: "https://example.com/higher.png",
+            wins: 2000,
+          },
+          {
+            handle: "second-member",
+            maxRating: 2300,
+            photoURL: null,
+            wins: 1800,
+          },
+          {
+            handle: "top-member",
+            maxRating: 2200,
+            photoURL: null,
+            wins: 1768,
+          },
+        ],
       },
     ]);
     expect(sql.load).toHaveBeenCalledWith(

--- a/src/statistics/general-statistics.service.spec.ts
+++ b/src/statistics/general-statistics.service.spec.ts
@@ -1,0 +1,149 @@
+import { DbService } from "../db/db.service";
+import { SqlLoaderService } from "../common/sql-loader.service";
+import { GeneralStatisticsService } from "./general-statistics.service";
+
+describe("GeneralStatisticsService", () => {
+  const db = {
+    query: jest.fn(),
+  };
+  const sql = {
+    load: jest.fn().mockReturnValue("SELECT tooltip data"),
+  };
+  const service = new GeneralStatisticsService(
+    db as unknown as DbService,
+    sql as unknown as SqlLoaderService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("normalizes top winners and nullable profile fields", async () => {
+    db.query.mockResolvedValue([
+      {
+        country_code: "IND",
+        "challenge_stats.count": "42",
+        rank: "2",
+        top_winners: [
+          {
+            handle: "winner",
+            maxRating: "1499",
+            photoURL: null,
+            wins: "12",
+          },
+          {
+            handle: "newcomer",
+            maxRating: null,
+            photoURL: "https://example.com/avatar.png",
+            wins: 5,
+          },
+        ],
+      },
+    ]);
+
+    await expect(service.getTopWinnersByCountry()).resolves.toEqual([
+      {
+        "country.country_name": "India",
+        "challenge_stats.count": 42,
+        rank: 2,
+        topWinners: [
+          {
+            handle: "winner",
+            maxRating: 1499,
+            photoURL: null,
+            wins: 12,
+          },
+          {
+            handle: "newcomer",
+            maxRating: null,
+            photoURL: "https://example.com/avatar.png",
+            wins: 5,
+          },
+        ],
+      },
+    ]);
+    expect(sql.load).toHaveBeenCalledWith(
+      "reports/statistics/general/top-winners-by-country.sql",
+    );
+  });
+
+  it("uses safe defaults when winner details are absent", async () => {
+    db.query.mockResolvedValue([
+      {
+        country_code: null,
+        "challenge_stats.count": null,
+        rank: null,
+        top_winners: null,
+      },
+    ]);
+
+    await expect(service.getTopWinnersByCountry()).resolves.toEqual([
+      {
+        "country.country_name": "",
+        "challenge_stats.count": 0,
+        rank: null,
+        topWinners: [],
+      },
+    ]);
+  });
+
+  it("normalizes country member, skill, and top-member details", async () => {
+    db.query.mockResolvedValue([
+      {
+        country_code: "IND",
+        "user.count": "730554",
+        top_member: {
+          handle: "top-member",
+          maxRating: "2200",
+          photoURL: null,
+          wins: "1768",
+        },
+        skills: [
+          { count: "40", name: "JavaScript" },
+          { count: "30", name: "Python" },
+          { count: "15", name: "Swift" },
+        ],
+      },
+      {
+        country_code: "IN",
+        "user.count": "10",
+        top_member: {
+          handle: "higher-winner",
+          maxRating: "2400",
+          photoURL: "https://example.com/higher.png",
+          wins: "2000",
+        },
+        skills: [
+          { count: "10", name: "javascript" },
+          { count: "25", name: "Rust" },
+          { count: "20", name: "Go" },
+        ],
+      },
+    ]);
+
+    await expect(service.getCountryMemberDetails()).resolves.toEqual([
+      {
+        "country.country_name": "India",
+        "country.country_code": "IND",
+        "user.count": 730564,
+        rank: 1,
+        skillAssignments: 140,
+        topMember: {
+          handle: "higher-winner",
+          maxRating: 2400,
+          photoURL: "https://example.com/higher.png",
+          wins: 2000,
+        },
+        topSkills: [
+          { count: 50, name: "JavaScript" },
+          { count: 30, name: "Python" },
+          { count: 25, name: "Rust" },
+        ],
+        totalSkills: 5,
+      },
+    ]);
+    expect(sql.load).toHaveBeenCalledWith(
+      "reports/statistics/general/country-member-details.sql",
+    );
+  });
+});

--- a/src/statistics/general-statistics.service.ts
+++ b/src/statistics/general-statistics.service.ts
@@ -3,6 +3,28 @@ import { DbService } from "../db/db.service";
 import { SqlLoaderService } from "../common/sql-loader.service";
 import { alpha3ToCountryName } from "../common/country.util";
 
+type CountryMember = {
+  handle: string;
+  maxRating: number | null;
+  photoURL: string | null;
+  wins: number;
+};
+
+type CountryMemberDetailRow = {
+  country_code: string | null;
+  "user.count": number | string | null;
+  skills: Array<{
+    count?: number | string | null;
+    name?: string | null;
+  }> | null;
+  top_member: {
+    handle?: string | null;
+    maxRating?: number | string | null;
+    photoURL?: string | null;
+    wins?: number | string | null;
+  } | null;
+};
+
 @Injectable()
 export class GeneralStatisticsService {
   constructor(
@@ -54,6 +76,104 @@ export class GeneralStatisticsService {
     });
   }
 
+  async getCountryMemberDetails() {
+    const q = this.sql.load(
+      "reports/statistics/general/country-member-details.sql",
+    );
+    const rows = await this.db.query<CountryMemberDetailRow>(q);
+    const countries = new Map<
+      string,
+      {
+        countryCode: string | null;
+        memberCount: number;
+        skills: Map<string, { count: number; name: string }>;
+        topMember: CountryMember | null;
+      }
+    >();
+
+    rows.forEach((row) => {
+      const countryName =
+        alpha3ToCountryName(row.country_code) ?? row.country_code ?? "";
+      const current = countries.get(countryName) ?? {
+        countryCode: row.country_code,
+        memberCount: 0,
+        skills: new Map<string, { count: number; name: string }>(),
+        topMember: null,
+      };
+      const candidate = row.top_member
+        ? {
+            handle: String(row.top_member.handle ?? ""),
+            maxRating:
+              row.top_member.maxRating !== null &&
+              row.top_member.maxRating !== undefined
+                ? Number(row.top_member.maxRating)
+                : null,
+            photoURL: row.top_member.photoURL ?? null,
+            wins: Number(row.top_member.wins ?? 0),
+          }
+        : null;
+
+      current.memberCount += Number(row["user.count"] ?? 0);
+      (Array.isArray(row.skills) ? row.skills : []).forEach((skill) => {
+        const name = String(skill.name ?? "").trim();
+        const count = Number(skill.count ?? 0);
+        if (!name || !Number.isFinite(count) || count <= 0) {
+          return;
+        }
+
+        const key = name.toLowerCase();
+        const existing = current.skills.get(key);
+        current.skills.set(key, {
+          count: (existing?.count ?? 0) + count,
+          name: existing?.name ?? name,
+        });
+      });
+      if (
+        candidate &&
+        (!current.topMember ||
+          candidate.wins > current.topMember.wins ||
+          (candidate.wins === current.topMember.wins &&
+            candidate.handle.localeCompare(current.topMember.handle) < 0))
+      ) {
+        current.topMember = candidate;
+      }
+      countries.set(countryName, current);
+    });
+
+    const mergedCountries = Array.from(countries.entries()).sort(
+      ([nameA, countryA], [nameB, countryB]) =>
+        countryB.memberCount - countryA.memberCount ||
+        nameA.localeCompare(nameB),
+    );
+    let rank = 0;
+    let previousCount: number | undefined;
+
+    return mergedCountries.map(([countryName, country]) => {
+      if (country.memberCount !== previousCount) {
+        rank += 1;
+        previousCount = country.memberCount;
+      }
+      const skills = Array.from(country.skills.values()).sort(
+        (skillA, skillB) =>
+          skillB.count - skillA.count || skillA.name.localeCompare(skillB.name),
+      );
+
+      return {
+        "country.country_name": countryName,
+        "country.country_code": country.countryCode,
+        "user.count": country.memberCount,
+        rank,
+        skillAssignments: skills.reduce(
+          (total, skill) => total + skill.count,
+          0,
+        ),
+        topMember: country.topMember,
+        topSkills: skills.slice(0, 3),
+        totalSkills: skills.length,
+      };
+    });
+  }
+
   async getFirstPlaceByCountry() {
     const q = this.sql.load(
       "reports/statistics/general/first-place-by-country.sql",
@@ -71,6 +191,47 @@ export class GeneralStatisticsService {
         "challenge_stats.count": Number(row["challenge_stats.count"] ?? 0),
         rank:
           row.rank !== null && row.rank !== undefined ? Number(row.rank) : null,
+      };
+    });
+  }
+
+  async getTopWinnersByCountry() {
+    const q = this.sql.load(
+      "reports/statistics/general/top-winners-by-country.sql",
+    );
+    const rows = await this.db.query<{
+      country_code: string | null;
+      "challenge_stats.count": number | string | null;
+      rank: number | string | null;
+      top_winners: Array<{
+        handle?: string | null;
+        maxRating?: number | string | null;
+        photoURL?: string | null;
+        wins?: number | string | null;
+      }> | null;
+    }>(q);
+
+    return rows.map((row) => {
+      const countryName =
+        alpha3ToCountryName(row.country_code) ?? row.country_code ?? "";
+      const topWinners = Array.isArray(row.top_winners)
+        ? row.top_winners.map((winner) => ({
+            handle: String(winner.handle ?? ""),
+            maxRating:
+              winner.maxRating !== null && winner.maxRating !== undefined
+                ? Number(winner.maxRating)
+                : null,
+            photoURL: winner.photoURL ?? null,
+            wins: Number(winner.wins ?? 0),
+          }))
+        : [];
+
+      return {
+        "country.country_name": countryName,
+        "challenge_stats.count": Number(row["challenge_stats.count"] ?? 0),
+        rank:
+          row.rank !== null && row.rank !== undefined ? Number(row.rank) : null,
+        topWinners,
       };
     });
   }

--- a/src/statistics/general-statistics.service.ts
+++ b/src/statistics/general-statistics.service.ts
@@ -16,13 +16,14 @@ type CountryMemberDetailRow = {
   skills: Array<{
     count?: number | string | null;
     name?: string | null;
+    ownedCount?: number | string | null;
   }> | null;
-  top_member: {
+  top_members: Array<{
     handle?: string | null;
     maxRating?: number | string | null;
     photoURL?: string | null;
     wins?: number | string | null;
-  } | null;
+  }> | null;
 };
 
 @Injectable()
@@ -86,8 +87,11 @@ export class GeneralStatisticsService {
       {
         countryCode: string | null;
         memberCount: number;
-        skills: Map<string, { count: number; name: string }>;
-        topMember: CountryMember | null;
+        skills: Map<
+          string,
+          { count: number; name: string; ownedCount: number }
+        >;
+        topMembers: CountryMember[];
       }
     >();
 
@@ -97,27 +101,35 @@ export class GeneralStatisticsService {
       const current = countries.get(countryName) ?? {
         countryCode: row.country_code,
         memberCount: 0,
-        skills: new Map<string, { count: number; name: string }>(),
-        topMember: null,
+        skills: new Map<
+          string,
+          { count: number; name: string; ownedCount: number }
+        >(),
+        topMembers: [],
       };
-      const candidate = row.top_member
-        ? {
-            handle: String(row.top_member.handle ?? ""),
-            maxRating:
-              row.top_member.maxRating !== null &&
-              row.top_member.maxRating !== undefined
-                ? Number(row.top_member.maxRating)
-                : null,
-            photoURL: row.top_member.photoURL ?? null,
-            wins: Number(row.top_member.wins ?? 0),
-          }
-        : null;
+      const candidates = (
+        Array.isArray(row.top_members) ? row.top_members : []
+      ).map((member) => ({
+        handle: String(member.handle ?? ""),
+        maxRating:
+          member.maxRating !== null && member.maxRating !== undefined
+            ? Number(member.maxRating)
+            : null,
+        photoURL: member.photoURL ?? null,
+        wins: Number(member.wins ?? 0),
+      }));
 
       current.memberCount += Number(row["user.count"] ?? 0);
       (Array.isArray(row.skills) ? row.skills : []).forEach((skill) => {
         const name = String(skill.name ?? "").trim();
         const count = Number(skill.count ?? 0);
-        if (!name || !Number.isFinite(count) || count <= 0) {
+        const ownedCount = Number(skill.ownedCount ?? 0);
+        if (
+          !name ||
+          !Number.isFinite(count) ||
+          !Number.isFinite(ownedCount) ||
+          ownedCount <= 0
+        ) {
           return;
         }
 
@@ -126,17 +138,10 @@ export class GeneralStatisticsService {
         current.skills.set(key, {
           count: (existing?.count ?? 0) + count,
           name: existing?.name ?? name,
+          ownedCount: (existing?.ownedCount ?? 0) + ownedCount,
         });
       });
-      if (
-        candidate &&
-        (!current.topMember ||
-          candidate.wins > current.topMember.wins ||
-          (candidate.wins === current.topMember.wins &&
-            candidate.handle.localeCompare(current.topMember.handle) < 0))
-      ) {
-        current.topMember = candidate;
-      }
+      current.topMembers.push(...candidates);
       countries.set(countryName, current);
     });
 
@@ -157,19 +162,40 @@ export class GeneralStatisticsService {
         (skillA, skillB) =>
           skillB.count - skillA.count || skillA.name.localeCompare(skillB.name),
       );
+      const totalOwnedSkills = skills.reduce(
+        (total, skill) => total + skill.ownedCount,
+        0,
+      );
+      const topMembersByHandle = new Map<string, CountryMember>();
+      country.topMembers
+        .sort(
+          (memberA, memberB) =>
+            memberB.wins - memberA.wins ||
+            memberA.handle.localeCompare(memberB.handle),
+        )
+        .forEach((member) => {
+          const key = member.handle.toLowerCase();
+          if (key && !topMembersByHandle.has(key)) {
+            topMembersByHandle.set(key, member);
+          }
+        });
+      const topMembers = Array.from(topMembersByHandle.values()).slice(0, 3);
 
       return {
         "country.country_name": countryName,
         "country.country_code": country.countryCode,
         "user.count": country.memberCount,
         rank,
-        skillAssignments: skills.reduce(
-          (total, skill) => total + skill.count,
-          0,
-        ),
-        topMember: country.topMember,
-        topSkills: skills.slice(0, 3),
+        skillsBreakdown: skills.slice(0, 3).map((skill) => ({
+          count: skill.count,
+          name: skill.name,
+          percentage:
+            totalOwnedSkills > 0
+              ? (skill.ownedCount / totalOwnedSkills) * 100
+              : 0,
+        })),
         totalSkills: skills.length,
+        topMembers,
       };
     });
   }

--- a/src/statistics/statistics-general.controller.ts
+++ b/src/statistics/statistics-general.controller.ts
@@ -33,10 +33,26 @@ export class StatisticsGeneralController {
     return this.general.getCountriesRepresented();
   }
 
+  @Get("/country-member-details")
+  @ApiOperation({
+    summary: "Member, skill, and top-member details by country (desc)",
+  })
+  getCountryMemberDetails() {
+    return this.general.getCountryMemberDetails();
+  }
+
   @Get("/first-place-by-country")
   @ApiOperation({ summary: "First place finishes by country (desc)" })
   getFirstPlaceByCountry() {
     return this.general.getFirstPlaceByCountry();
+  }
+
+  @Get("/top-winners-by-country")
+  @ApiOperation({
+    summary: "First place finishes and top three winners by country (desc)",
+  })
+  getTopWinnersByCountry() {
+    return this.general.getTopWinnersByCountry();
   }
 
   @Get("/copiloted-challenges")

--- a/src/statistics/statistics-general.sql.spec.ts
+++ b/src/statistics/statistics-general.sql.spec.ts
@@ -1,0 +1,59 @@
+import { SqlLoaderService } from "../common/sql-loader.service";
+
+describe("General statistics SQL", () => {
+  const sqlLoader = new SqlLoaderService();
+
+  function expectMemberStatsWins(sql: string) {
+    expect(sql).toContain('FROM members."memberStats" stats');
+    expect(sql).toContain('FROM members."memberStatsHistory" history');
+    expect(sql).toContain("history.placement = 1");
+    expect(sql).toContain('stats."isPrivate" = false');
+    expect(sql).toContain("SUM(COALESCE(stats.wins, history.wins, 0))");
+    expect(sql).toContain('JOIN challenges."ChallengeTrack" track');
+    expect(sql).not.toContain('challenges."ChallengeWinner"');
+    expect(sql).not.toContain("reviews.submission");
+  }
+
+  it("returns at most three deterministically ranked winners per country", () => {
+    const sql = sqlLoader.load(
+      "reports/statistics/general/top-winners-by-country.sql",
+    );
+
+    expectMemberStatsWins(sql);
+    expect(sql).toContain("PARTITION BY country_code");
+    expect(sql).toContain("ORDER BY wins DESC, handle ASC, user_id ASC");
+    expect(sql).toContain("winner_rank <= 3");
+    expect(sql).toContain('m."photoURL" AS photo_url');
+    expect(sql).toContain('members."memberMaxRating"');
+    expect(sql).toContain("'maxRating', max_rating");
+    expect(sql).toContain('first_place_count AS "challenge_stats.count"');
+  });
+
+  it("aggregates country skills and one deterministic top member", () => {
+    const sql = sqlLoader.load(
+      "reports/statistics/general/country-member-details.sql",
+    );
+
+    expect(sql).toContain("JOIN skills.user_skill user_skill");
+    expect(sql).toContain("JOIN skills.user_skill_display_mode display_mode");
+    expect(sql).toContain("LOWER(display_mode.name) = 'principal'");
+    expect(sql).toContain("COUNT(DISTINCT user_skill.user_id)");
+    expect(sql).toContain("JOIN skills.skill skill");
+    expect(sql).toContain("skill.deleted_at IS NULL");
+    expect(sql).toContain("ORDER BY member_count DESC, name ASC, skill_id ASC");
+    expect(sql).toContain("AS skills");
+    expect(sql).not.toContain("skill_rank <= 3");
+    expectMemberStatsWins(sql);
+    expect(sql).toContain("ORDER BY wins DESC, handle ASC, user_id ASC");
+    expect(sql).toContain("WHERE member_rank = 1");
+    expect(sql).toContain('countries.members_count AS "user.count"');
+  });
+
+  it("uses public member stats wins for country totals", () => {
+    const sql = sqlLoader.load(
+      "reports/statistics/general/first-place-by-country.sql",
+    );
+
+    expectMemberStatsWins(sql);
+  });
+});

--- a/src/statistics/statistics-general.sql.spec.ts
+++ b/src/statistics/statistics-general.sql.spec.ts
@@ -29,23 +29,28 @@ describe("General statistics SQL", () => {
     expect(sql).toContain('first_place_count AS "challenge_stats.count"');
   });
 
-  it("aggregates country skills and one deterministic top member", () => {
+  it("aggregates owned skills and three deterministic top members", () => {
     const sql = sqlLoader.load(
       "reports/statistics/general/country-member-details.sql",
     );
 
+    expect(sql).toContain("NULLIF(TRIM(m.\"homeCountryCode\"), '')");
     expect(sql).toContain("JOIN skills.user_skill user_skill");
-    expect(sql).toContain("JOIN skills.user_skill_display_mode display_mode");
-    expect(sql).toContain("LOWER(display_mode.name) = 'principal'");
-    expect(sql).toContain("COUNT(DISTINCT user_skill.user_id)");
+    expect(sql).toContain("JOIN skills.user_skill_level skill_level");
+    expect(sql).toContain(
+      "LOWER(skill_level.name) IN ('verified', 'self-declared')",
+    );
+    expect(sql).toContain("COUNT(*)::bigint AS owned_count");
+    expect(sql).not.toContain("user_skill_win_summary");
+    expect(sql).toContain("'ownedCount', owned_count");
     expect(sql).toContain("JOIN skills.skill skill");
     expect(sql).toContain("skill.deleted_at IS NULL");
-    expect(sql).toContain("ORDER BY member_count DESC, name ASC, skill_id ASC");
+    expect(sql).toContain("ORDER BY owned_count DESC, name ASC, skill_id ASC");
     expect(sql).toContain("AS skills");
     expect(sql).not.toContain("skill_rank <= 3");
     expectMemberStatsWins(sql);
     expect(sql).toContain("ORDER BY wins DESC, handle ASC, user_id ASC");
-    expect(sql).toContain("WHERE member_rank = 1");
+    expect(sql).toContain("member_rank <= 3");
     expect(sql).toContain('countries.members_count AS "user.count"');
   });
 


### PR DESCRIPTION
This pull request adds two new country-level statistics reports—"Country Member Details" and "Top Winners by Country"—and implements their backend logic, SQL queries, and API endpoints. It also updates the report directory and test coverage to include these new reports. The key changes are grouped below:

**New Reports and Directory Integration:**

* Added "Country Member Details" and "Top Winners by Country" reports to the registered reports directory and made them available in the statistics section. [[1]](diffhunk://#diff-1c39a34d92658d418c9990c9ccf240db3400685d26da2be683400e7c4e916ab6R543-R557) [[2]](diffhunk://#diff-feceb8132772ca862abea124f914d436a2e4427c6f60ad56f68b9ed2a62dcf36R22-R27)
* Updated tests to verify the presence of these new reports in the accessible reports directory.

**SQL Query Additions and Improvements:**

* Added `country-member-details.sql` and `top-winners-by-country.sql` to compute, respectively, member/skill/top-winner breakdowns by country and the top three winners per country, using enhanced logic for accurate aggregation and normalization. [[1]](diffhunk://#diff-cbae4d7e71168d9363eb912c48a49a512902c748fe471edee88dcbe7b5feb7ddR1-R143) [[2]](diffhunk://#diff-daaa62d6ca59208d371158720ae906641aeb5dcb931af20053372d229287db54R1-R97)
* Refactored `first-place-by-country.sql` to use consistent aggregation logic with the new reports. [[1]](diffhunk://#diff-6eaa2503504cf7b64f645720de3cc9aa878f786f595fb4512779f4b604a698ccL1-R42) [[2]](diffhunk://#diff-6eaa2503504cf7b64f645720de3cc9aa878f786f595fb4512779f4b604a698ccL22-R51)

**Backend Logic and API Endpoints:**

* Implemented `getCountryMemberDetails` and `getTopWinnersByCountry` methods in `GeneralStatisticsService` to normalize, aggregate, and return the new report data with country names, member counts, skill breakdowns, and top winner details. [[1]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affR6-R28) [[2]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affR80-R202) [[3]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affR224-R264)
* Added corresponding API endpoints to `StatisticsGeneralController` for accessing the new reports.

**Testing Enhancements:**

* Added comprehensive tests for data normalization, aggregation, and edge cases for the new service methods in `general-statistics.service.spec.ts`.

These changes collectively provide richer, more detailed country-level statistics and make them accessible through both the UI and API.