### PR TITLE
PM-4620 - fix report for member details

### DIFF
--- a/sql/reports/statistics/general/country-member-details.sql
+++ b/sql/reports/statistics/general/country-member-details.sql
@@ -2,8 +2,8 @@ WITH member_profiles AS (
   SELECT
     m."userId" AS user_id,
     COALESCE(
-      NULLIF(TRIM(m."competitionCountryCode"), ''),
-      NULLIF(TRIM(m."homeCountryCode"), '')
+      NULLIF(TRIM(m."homeCountryCode"), ''),
+      NULLIF(TRIM(m."competitionCountryCode"), '')
     ) AS country_code,
     m.handle,
     m."photoURL" AS photo_url

--- a/sql/reports/statistics/general/first-place-by-country.sql
+++ b/sql/reports/statistics/general/first-place-by-country.sql
@@ -33,8 +33,8 @@ member_wins AS (
 winners_country AS (
   SELECT
     COALESCE(
-      NULLIF(TRIM(m."competitionCountryCode"), ''),
-      NULLIF(TRIM(m."homeCountryCode"), '')
+      NULLIF(TRIM(m."homeCountryCode"), ''),
+      NULLIF(TRIM(m."competitionCountryCode"), '')
     ) AS country_code,
     w.wins
   FROM member_wins w

--- a/sql/reports/statistics/general/top-winners-by-country.sql
+++ b/sql/reports/statistics/general/top-winners-by-country.sql
@@ -33,8 +33,8 @@ stats_wins AS (
 winner_profiles AS (
   SELECT
     COALESCE(
-      NULLIF(TRIM(m."competitionCountryCode"), ''),
-      NULLIF(TRIM(m."homeCountryCode"), '')
+      NULLIF(TRIM(m."homeCountryCode"), ''),
+      NULLIF(TRIM(m."competitionCountryCode"), '')
     ) AS country_code,
     m."userId" AS user_id,
     m.handle,
@@ -47,8 +47,8 @@ winner_profiles AS (
   LEFT JOIN members."memberMaxRating" mmr
     ON mmr."userId" = m."userId"
   WHERE COALESCE(
-    NULLIF(TRIM(m."competitionCountryCode"), ''),
-    NULLIF(TRIM(m."homeCountryCode"), '')
+    NULLIF(TRIM(m."homeCountryCode"), ''),
+    NULLIF(TRIM(m."competitionCountryCode"), '')
   ) IS NOT NULL
     AND wins.wins > 0
 ),


### PR DESCRIPTION
This pull request updates the logic for determining a member's country code in several SQL report queries. The main change is to prioritize `homeCountryCode` over `competitionCountryCode` when both are present or non-empty. This ensures consistency in how country codes are assigned across different reports.

**Country code selection logic update:**

* In `general/country-member-details.sql`, the `member_profiles` CTE now uses `homeCountryCode` first in the `COALESCE` expression for `country_code`.
* In `general/first-place-by-country.sql`, the `winners_country` CTE now prioritizes `homeCountryCode` over `competitionCountryCode` for `country_code`.
* In `general/top-winners-by-country.sql`, both the `winner_profiles` CTE and its `WHERE` clause now use `homeCountryCode` before `competitionCountryCode` in the `COALESCE` expressions for `country_code`. [[1]](diffhunk://#diff-daaa62d6ca59208d371158720ae906641aeb5dcb931af20053372d229287db54L36-R37) [[2]](diffhunk://#diff-daaa62d6ca59208d371158720ae906641aeb5dcb931af20053372d229287db54L50-R51)