### PR TITLE
PM-5834 - add support for live leaderboard scoring based on ai decissions

### DIFF
--- a/sql/reports/topcoder/leaderboard-generic.sql
+++ b/sql/reports/topcoder/leaderboard-generic.sql
@@ -2,6 +2,7 @@ WITH challenge_context AS (
   SELECT
     c.id AS challenge_id,
     c.name AS challenge_name,
+    c.status AS challenge_status,
     COALESCE(
       cp."actualStartDate",
       cp."scheduledStartDate"
@@ -28,12 +29,14 @@ member_submissions AS (
     cc.challenge_id,
     s.id AS submission_id,
     s."memberId" AS user_id,
+    cc.challenge_status,
     COALESCE(
       NULLIF(TRIM(u.handle), ''),
       NULLIF(TRIM(mem.handle), ''),
       fallback.member_handle
     ) AS handle,
     COALESCE(NULLIF(TRIM(mem."firstName"), ''), NULLIF(TRIM(u.handle), ''), NULLIF(TRIM(mem.handle), '')) AS name,
+    challenge_reviewers.is_ai_only_challenge AS is_ai_only_challenge,
     COALESCE(
       home_code.name,
       home_id.name,
@@ -52,6 +55,7 @@ member_submissions AS (
     COALESCE(
       CASE
         WHEN challenge_reviewers.is_ai_only_challenge
+          OR ($2::boolean = TRUE AND cc.challenge_status <> 'COMPLETED')
           THEN ai_decision."totalScore"
         ELSE final_review."aggregateScore"
       END,
@@ -119,7 +123,7 @@ member_submissions AS (
     ON UPPER(comp_id.id) = UPPER(mem."competitionCountryCode")
   WHERE COALESCE(
           CASE
-            WHEN challenge_reviewers.is_ai_only_challenge
+            WHEN ($2::boolean = TRUE AND cc.challenge_status <> 'COMPLETED') OR challenge_reviewers.is_ai_only_challenge
               THEN ai_decision."totalScore"
             ELSE final_review."aggregateScore"
           END,
@@ -127,7 +131,8 @@ member_submissions AS (
           s."initialScore"::double precision
         ) IS NOT NULL
     AND (
-      (challenge_reviewers.is_ai_only_challenge
+      ((challenge_reviewers.is_ai_only_challenge
+        OR ($2::boolean = TRUE AND cc.challenge_status <> 'COMPLETED'))
         AND UPPER(ai_decision.status::text) = 'PASSED')
       OR (
         NOT challenge_reviewers.is_ai_only_challenge
@@ -192,6 +197,8 @@ SELECT
   ums.user_id AS "userId",
   ums.handle AS handle,
   ums.name AS name,
+  ums.challenge_status AS "challengeStatus",
+  ums.is_ai_only_challenge AS "isAiOnlyChallenge",
   COALESCE(
     home_code.name,
     home_id.name,

--- a/src/reports/topcoder/dto/leaderboard-generic.dto.ts
+++ b/src/reports/topcoder/dto/leaderboard-generic.dto.ts
@@ -39,4 +39,9 @@ export class LeaderboardGenericQueryDto {
   @IsOptional()
   @IsBoolean()
   showHeadingAndSubtitle?: boolean;
+
+  @Transform(({ value }) => value === "true" || value === true)
+  @IsOptional()
+  @IsBoolean()
+  showRealtimeScore?: boolean;
 }

--- a/src/reports/topcoder/topcoder-reports.service.spec.ts
+++ b/src/reports/topcoder/topcoder-reports.service.spec.ts
@@ -178,4 +178,68 @@ describe("TopcoderReportsService", () => {
 
     expect(db.query).not.toHaveBeenCalled();
   });
+
+  it("passes showRealtimeScore to the generic leaderboard query and marks active AI-only rows as provisional when enabled", async () => {
+    const genericRow = {
+      challengeId: "ch1",
+      challengeName: "Challenge One",
+      durationDays: 1,
+      prizePool: 1000,
+      submissionsCount: 1,
+      placementPrizes: null,
+      userId: "u1",
+      handle: "user1",
+      name: "User One",
+      country: "USA",
+      countryCode: "US",
+      photoURL: null,
+      rating: 1500,
+      ratingColor: "#000000",
+      score: 123,
+      submittedDate: "2026-08-13T00:00:00Z",
+      placement: 1,
+      challengeStatus: "ACTIVE",
+      isAiOnlyChallenge: true,
+    };
+
+    db.query.mockResolvedValueOnce([genericRow]);
+
+    const resultWithRealtime = await service.getLeaderboardGeneric({
+      challengeIds: ["ch1"],
+      pointsPerDay: 10,
+      placementPrizeAmounts: [],
+      showRealtimeScore: true,
+    });
+
+    expect(sql.load).toHaveBeenCalledWith(
+      "reports/topcoder/leaderboard-generic.sql",
+    );
+    expect(db.query).toHaveBeenCalledWith(
+      "reports/topcoder/leaderboard-generic.sql",
+      [["ch1"], true],
+    );
+    expect(resultWithRealtime.placementData).toHaveLength(1);
+    expect(resultWithRealtime.placementData[0].challengeScores?.ch1).toEqual({
+      score: 123,
+      isProvisional: true,
+    });
+
+    db.query.mockResolvedValueOnce([genericRow]);
+
+    const resultWithoutRealtime = await service.getLeaderboardGeneric({
+      challengeIds: ["ch1"],
+      pointsPerDay: 10,
+      placementPrizeAmounts: [],
+      showRealtimeScore: false,
+    });
+
+    expect(db.query).toHaveBeenCalledWith(
+      "reports/topcoder/leaderboard-generic.sql",
+      [["ch1"], false],
+    );
+    expect(resultWithoutRealtime.placementData[0].challengeScores?.ch1).toEqual({
+      score: 123,
+      isProvisional: false,
+    });
+  });
 });

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -118,6 +118,8 @@ type LeaderboardGenericRow = {
   score: number;
   submittedDate: string;
   placement: number;
+  challengeStatus: string;
+  isAiOnlyChallenge: boolean;
 };
 
 type LeaderboardMmRow = {
@@ -1007,10 +1009,12 @@ export class TopcoderReportsService implements OnModuleDestroy {
     pointsPerDay?: number;
     placementPrizeAmounts?: string[];
     showHeadingAndSubtitle?: boolean;
+    showRealtimeScore?: boolean;
   }) {
     const query = this.sql.load("reports/topcoder/leaderboard-generic.sql");
     const rows = await this.db.query<LeaderboardGenericRow>(query, [
       filters.challengeIds,
+      filters.showRealtimeScore === true,
     ]);
 
     const useCmsPlacementPrizes =
@@ -1038,6 +1042,10 @@ export class TopcoderReportsService implements OnModuleDestroy {
         photoURL: string | null;
         rating: number;
         ratingColor: string | null;
+        challengeScores: Record<
+          string,
+          { score: number; isProvisional: boolean }
+        >;
       }
     > = {};
 
@@ -1062,6 +1070,7 @@ export class TopcoderReportsService implements OnModuleDestroy {
           prizes: 0,
           rating: row.rating as number,
           ratingColor: row.ratingColor,
+          challengeScores: {},
         };
       }
 
@@ -1074,6 +1083,12 @@ export class TopcoderReportsService implements OnModuleDestroy {
 
       entriesByUser[row.userId].points += pointsByWin;
       entriesByUser[row.userId].wins[row.challengeId] = pointsByWin;
+      entriesByUser[row.userId].challengeScores[row.challengeId] = {
+        score: row.score,
+        isProvisional:
+          filters.showRealtimeScore === true &&
+          row.challengeStatus !== "COMPLETED",
+      };
       if (!useCmsPlacementPrizes) {
         const prizeValue =
           (row.placementPrizes ?? []).find((p) => p.placement === row.placement)
@@ -1095,6 +1110,7 @@ export class TopcoderReportsService implements OnModuleDestroy {
         placement: index,
         points: entry.points,
         wins: entry.wins,
+        challengeScores: entry.challengeScores,
         rating: entry.rating,
         ratingColor: entry.ratingColor,
         prizes: useCmsPlacementPrizes


### PR DESCRIPTION
This pull request enhances the Topcoder leaderboard report to support real-time (provisional) scoring and exposes additional challenge metadata. The main changes include updating the SQL query and TypeScript service to allow toggling between final and real-time scores, tracking whether a challenge is AI-only, and providing richer data to the frontend.

**Leaderboard scoring and challenge status enhancements:**

* Added a new `showRealtimeScore` boolean parameter to the leaderboard API and DTO, allowing clients to request real-time (provisional) scores instead of only final scores (`src/reports/topcoder/dto/leaderboard-generic.dto.ts`, `src/reports/topcoder/topcoder-reports.service.ts`) [[1]](diffhunk://#diff-2da9858001d23c5861382c788221854cbda4291b6c179a57a4154719c3acd5bfR42-R46) [[2]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R1012-R1017).
* Modified the SQL query to select and return real-time scores when `showRealtimeScore` is enabled and the challenge is not completed, and to include `challenge_status` and `is_ai_only_challenge` in the result set (`sql/reports/topcoder/leaderboard-generic.sql`) [[1]](diffhunk://#diff-cc8935795c2a64f4570adeb954d693ca0ba0b3411d38b7f3e7819ab82ce94b29R5) [[2]](diffhunk://#diff-cc8935795c2a64f4570adeb954d693ca0ba0b3411d38b7f3e7819ab82ce94b29R32-R39) [[3]](diffhunk://#diff-cc8935795c2a64f4570adeb954d693ca0ba0b3411d38b7f3e7819ab82ce94b29R58) [[4]](diffhunk://#diff-cc8935795c2a64f4570adeb954d693ca0ba0b3411d38b7f3e7819ab82ce94b29L122-R135) [[5]](diffhunk://#diff-cc8935795c2a64f4570adeb954d693ca0ba0b3411d38b7f3e7819ab82ce94b29R200-R201).

**TypeScript model and response updates:**

* Extended the `LeaderboardGenericRow` type and leaderboard API response to include `challengeStatus` and `isAiOnlyChallenge` fields, and to track per-challenge scores (including whether each score is provisional) for each user (`src/reports/topcoder/topcoder-reports.service.ts`) [[1]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R121-R122) [[2]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R1045-R1048) [[3]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R1073) [[4]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R1086-R1091) [[5]](diffhunk://#diff-e01e0fd29707675c7a860981aab01ddc6fa4e77b4bb6ab6914f751c19fb80f71R1113).

These changes allow the leaderboard to provide more accurate and timely information, especially for ongoing challenges and AI-only competitions.