### PR TITLE
PM-5370 - Campus leaderboard

### DIFF
--- a/sql/reports/topcoder/campus-leaderboard-group.sql
+++ b/sql/reports/topcoder/campus-leaderboard-group.sql
@@ -1,0 +1,48 @@
+-- Resolves a campus program group by name (or id / legacy id) and reports whether
+-- the caller ($2, an optional user id) belongs to it, directly or via a sub-group.
+-- $1 = group name (case insensitive), $2 = caller user id (nullable)
+WITH RECURSIVE params AS (
+  SELECT
+    LOWER(BTRIM($1)) AS group_key,
+    NULLIF(BTRIM(COALESCE($2, '')), '') AS caller_id
+),
+root_group AS (
+  SELECT
+    g.id,
+    g.name,
+    g."oldId",
+    g."privateGroup"
+  FROM groups."Group" AS g
+  CROSS JOIN params AS p
+  WHERE LOWER(g.name) = p.group_key
+     OR LOWER(g.id) = p.group_key
+     OR LOWER(COALESCE(g."oldId", '')) = p.group_key
+  ORDER BY (LOWER(g.name) = p.group_key) DESC, g."createdAt" ASC
+  LIMIT 1
+),
+group_tree AS (
+  SELECT rg.id
+  FROM root_group AS rg
+  UNION
+  SELECT gm."memberId"
+  FROM groups."GroupMember" AS gm
+  JOIN group_tree AS gt
+    ON gt.id = gm."groupId"
+  WHERE LOWER(gm."membershipType") = 'group'
+)
+SELECT
+  rg.id AS "groupId",
+  rg.name AS "groupName",
+  rg."oldId" AS "groupOldId",
+  rg."privateGroup" AS "privateGroup",
+  EXISTS (
+    SELECT 1
+    FROM groups."GroupMember" AS gm
+    JOIN group_tree AS gt
+      ON gt.id = gm."groupId"
+    CROSS JOIN params AS p
+    WHERE LOWER(gm."membershipType") = 'user'
+      AND p.caller_id IS NOT NULL
+      AND gm."memberId" = p.caller_id
+  ) AS "callerIsMember"
+FROM root_group AS rg;

--- a/sql/reports/topcoder/campus-leaderboard.sql
+++ b/sql/reports/topcoder/campus-leaderboard.sql
@@ -1,0 +1,248 @@
+-- Campus program leaderboard: every member of the requested group (including
+-- members with no challenge activity at all) with one row per challenge they
+-- registered for, submitted to, or won. Members without activity come back as a
+-- single row with a NULL "challengeId".
+-- $1 = group name (case insensitive, also accepts the group id / legacy id)
+WITH RECURSIVE params AS (
+  SELECT LOWER(BTRIM($1)) AS group_key
+),
+root_group AS (
+  SELECT
+    g.id,
+    g.name,
+    g."oldId"
+  FROM groups."Group" AS g
+  CROSS JOIN params AS p
+  WHERE LOWER(g.name) = p.group_key
+     OR LOWER(g.id) = p.group_key
+     OR LOWER(COALESCE(g."oldId", '')) = p.group_key
+  ORDER BY (LOWER(g.name) = p.group_key) DESC, g."createdAt" ASC
+  LIMIT 1
+),
+group_tree AS (
+  SELECT rg.id
+  FROM root_group AS rg
+  UNION
+  SELECT gm."memberId"
+  FROM groups."GroupMember" AS gm
+  JOIN group_tree AS gt
+    ON gt.id = gm."groupId"
+  WHERE LOWER(gm."membershipType") = 'group'
+),
+group_identifiers AS (
+  SELECT ARRAY(
+    SELECT DISTINCT identifier
+    FROM (
+      SELECT rg.id AS identifier FROM root_group AS rg
+      UNION ALL
+      SELECT rg."oldId" FROM root_group AS rg WHERE NULLIF(BTRIM(rg."oldId"), '') IS NOT NULL
+    ) AS identifiers
+  ) AS identifiers
+),
+group_members AS (
+  SELECT
+    gm."memberId" AS member_id,
+    MIN(gm."createdAt") AS joined_at
+  FROM groups."GroupMember" AS gm
+  JOIN group_tree AS gt
+    ON gt.id = gm."groupId"
+  WHERE LOWER(gm."membershipType") = 'user'
+    AND gm."memberId" ~ '^[0-9]+$'
+  GROUP BY gm."memberId"
+),
+registrant_roles AS (
+  SELECT rr.id
+  FROM resources."ResourceRole" AS rr
+  WHERE rr."nameLower" IN ('submitter', 'registrant')
+),
+member_registrations AS (
+  SELECT
+    r."memberId" AS member_id,
+    r."challengeId" AS challenge_id,
+    MIN(r."createdAt") AS registered_at
+  FROM resources."Resource" AS r
+  JOIN group_members AS gm
+    ON gm.member_id = r."memberId"
+  WHERE r."roleId" IN (SELECT id FROM registrant_roles)
+  GROUP BY r."memberId", r."challengeId"
+),
+scored_submissions AS (
+  SELECT
+    s."memberId" AS member_id,
+    s."challengeId" AS challenge_id,
+    COALESCE(s."submittedDate", s."createdAt") AS submitted_date,
+    COALESCE(
+      CASE
+        WHEN challenge_reviewers.is_ai_only_challenge
+          THEN ai_decision."totalScore"
+        ELSE final_review."aggregateScore"
+      END,
+      s."finalScore"::double precision,
+      s."initialScore"::double precision
+    ) AS score,
+    CASE
+      WHEN challenge_reviewers.is_ai_only_challenge
+        THEN UPPER(COALESCE(ai_decision.status::text, '')) = 'PASSED'
+      ELSE COALESCE(
+        final_review."isPassing",
+        CASE
+          WHEN COALESCE(
+                 final_review."aggregateScore",
+                 s."finalScore"::double precision,
+                 s."initialScore"::double precision
+               ) IS NULL
+            THEN FALSE
+          ELSE COALESCE(
+                 final_review."aggregateScore",
+                 s."finalScore"::double precision,
+                 s."initialScore"::double precision
+               ) >= COALESCE(sc."minimumPassingScore", sc."minScore", 0)
+        END
+      )
+    END AS is_passing
+  FROM reviews.submission AS s
+  JOIN group_members AS gm
+    ON gm.member_id = s."memberId"
+  LEFT JOIN LATERAL (
+    SELECT rs."aggregateScore", rs."scorecardId", rs."isPassing"
+    FROM reviews."reviewSummation" AS rs
+    WHERE rs."submissionId" = s.id
+      AND COALESCE(rs."isFinal", TRUE) = TRUE
+      AND rs."isProvisional" IS DISTINCT FROM TRUE
+    ORDER BY COALESCE(rs."reviewedDate", rs."createdAt") DESC NULLS LAST, rs.id DESC
+    LIMIT 1
+  ) AS final_review ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT
+      BOOL_AND(cr."aiWorkflowId" IS NOT NULL AND cr."isMemberReview" = FALSE)
+        AND COUNT(*) > 0 AS is_ai_only_challenge
+    FROM challenges."ChallengeReviewer" AS cr
+    WHERE cr."challengeId" = s."challengeId"
+  ) AS challenge_reviewers ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT d."totalScore", d.status
+    FROM reviews."aiReviewDecision" AS d
+    WHERE d."submissionId" = s.id
+      AND UPPER(d.status::text) != 'PENDING'
+    ORDER BY d."updatedAt" DESC NULLS LAST
+    LIMIT 1
+  ) AS ai_decision ON TRUE
+  LEFT JOIN reviews.scorecard AS sc
+    ON sc.id = final_review."scorecardId"
+  WHERE s."challengeId" IS NOT NULL
+    AND s.type = 'CONTEST_SUBMISSION'
+    AND s.status <> 'DELETED'
+),
+-- At most one submission (and one passing submission) is counted per member per challenge.
+member_submissions AS (
+  SELECT
+    ss.member_id,
+    ss.challenge_id,
+    MIN(ss.submitted_date) AS first_submitted_date,
+    BOOL_OR(COALESCE(ss.is_passing, FALSE)) AS has_passing_submission,
+    MAX(ss.score) FILTER (WHERE ss.score IS NOT NULL) AS best_score
+  FROM scored_submissions AS ss
+  GROUP BY ss.member_id, ss.challenge_id
+),
+member_wins AS (
+  SELECT
+    cw."userId"::text AS member_id,
+    cw."challengeId" AS challenge_id,
+    MIN(cw.placement) AS placement
+  FROM challenges."ChallengeWinner" AS cw
+  JOIN group_members AS gm
+    ON gm.member_id = cw."userId"::text
+  WHERE cw.placement = 1
+  GROUP BY cw."userId", cw."challengeId"
+),
+participation AS (
+  SELECT member_id, challenge_id FROM member_registrations
+  UNION
+  SELECT member_id, challenge_id FROM member_submissions
+  UNION
+  SELECT member_id, challenge_id FROM member_wins
+),
+member_participation AS (
+  SELECT
+    p.member_id,
+    c.id AS challenge_id,
+    c.name AS challenge_name,
+    c.status::text AS challenge_status,
+    ct.name AS challenge_type,
+    ctr.name AS challenge_track,
+    COALESCE(c."endDate", c."submissionEndDate", c."startDate") AS challenge_end_date,
+    (c.groups && gi.identifiers) AS is_campus_challenge,
+    (COALESCE(ARRAY_LENGTH(c.groups, 1), 0) = 0) AS is_public_challenge,
+    reg.registered_at,
+    (reg.member_id IS NOT NULL) AS registered,
+    (sub.member_id IS NOT NULL) AS submitted,
+    COALESCE(sub.has_passing_submission, FALSE) AS passed_review,
+    sub.first_submitted_date,
+    sub.best_score,
+    (win.member_id IS NOT NULL) AS won,
+    win.placement
+  FROM participation AS p
+  CROSS JOIN group_identifiers AS gi
+  JOIN challenges."Challenge" AS c
+    ON c.id = p.challenge_id
+  LEFT JOIN challenges."ChallengeType" AS ct
+    ON ct.id = c."typeId"
+  LEFT JOIN challenges."ChallengeTrack" AS ctr
+    ON ctr.id = c."trackId"
+  LEFT JOIN member_registrations AS reg
+    ON reg.member_id = p.member_id
+   AND reg.challenge_id = p.challenge_id
+  LEFT JOIN member_submissions AS sub
+    ON sub.member_id = p.member_id
+   AND sub.challenge_id = p.challenge_id
+  LEFT JOIN member_wins AS win
+    ON win.member_id = p.member_id
+   AND win.challenge_id = p.challenge_id
+),
+max_rating AS (
+  SELECT DISTINCT ON (mmr."userId")
+    mmr."userId",
+    mmr.rating,
+    mmr."ratingColor"
+  FROM members."memberMaxRating" AS mmr
+  ORDER BY mmr."userId", mmr.rating DESC
+)
+SELECT
+  gm.member_id AS "userId",
+  COALESCE(
+    NULLIF(BTRIM(u.handle), ''),
+    NULLIF(BTRIM(mem.handle), '')
+  ) AS handle,
+  mem."firstName" AS "firstName",
+  mem."lastName" AS "lastName",
+  mem."photoURL" AS "photoURL",
+  mr.rating AS rating,
+  mr."ratingColor" AS "ratingColor",
+  gm.joined_at AS "groupJoinedAt",
+  u.create_date AS "memberSince",
+  mp.challenge_id AS "challengeId",
+  mp.challenge_name AS "challengeName",
+  mp.challenge_status AS "challengeStatus",
+  mp.challenge_type AS "challengeType",
+  mp.challenge_track AS "challengeTrack",
+  mp.challenge_end_date AS "challengeEndDate",
+  mp.is_campus_challenge AS "isCampusChallenge",
+  mp.is_public_challenge AS "isPublicChallenge",
+  mp.registered_at AS "registeredAt",
+  mp.registered AS registered,
+  mp.submitted AS submitted,
+  mp.passed_review AS "passedReview",
+  mp.first_submitted_date AS "submittedDate",
+  mp.best_score AS score,
+  mp.won AS won,
+  mp.placement AS placement
+FROM group_members AS gm
+LEFT JOIN members."member" AS mem
+  ON mem."userId" = gm.member_id::bigint
+LEFT JOIN identity."user" AS u
+  ON u.user_id = gm.member_id::numeric
+LEFT JOIN max_rating AS mr
+  ON mr."userId" = gm.member_id::bigint
+LEFT JOIN member_participation AS mp
+  ON mp.member_id = gm.member_id
+ORDER BY gm.member_id, mp.challenge_end_date DESC NULLS LAST, mp.challenge_id;

--- a/src/auth/guards/topcoder-reports.guard.spec.ts
+++ b/src/auth/guards/topcoder-reports.guard.spec.ts
@@ -51,6 +51,15 @@ class TestTopcoderReportsController {
   getCompletedProfiles(): undefined {
     return undefined;
   }
+
+  /**
+   * Represents the campus leaderboard route, which any authenticated caller may read.
+   * Returns no value because the handler body is not exercised in these unit tests.
+   */
+  @RequiredScopes()
+  getCampusLeaderboard(): undefined {
+    return undefined;
+  }
 }
 
 type TestHandlerName = keyof TestTopcoderReportsController;
@@ -107,6 +116,12 @@ describe("TopcoderReportsGuard", () => {
         }),
       ),
     ).toThrow(ForbiddenException);
+  });
+
+  it("lets any authenticated caller reach the campus leaderboard", () => {
+    expect(
+      guard.canActivate(createExecutionContext("getCampusLeaderboard", {})),
+    ).toBe(true);
   });
 
   it("preserves the completed profiles talent manager exception", () => {

--- a/src/reports/topcoder/campus-leaderboard.service.spec.ts
+++ b/src/reports/topcoder/campus-leaderboard.service.spec.ts
@@ -1,0 +1,310 @@
+import { ForbiddenException, NotFoundException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { DbService } from "../../db/db.service";
+import { SqlLoaderService } from "../../common/sql-loader.service";
+import { TopcoderReportsService } from "./topcoder-reports.service";
+import { CampusChallengeFilter } from "./dto/campus-leaderboard.dto";
+
+const GROUP_QUERY = "reports/topcoder/campus-leaderboard-group.sql";
+const LEADERBOARD_QUERY = "reports/topcoder/campus-leaderboard.sql";
+
+type Row = Record<string, unknown>;
+
+const participationRow = (overrides: Row = {}): Row => ({
+  userId: "1",
+  handle: "member1",
+  firstName: "Member",
+  lastName: "One",
+  photoURL: null,
+  rating: null,
+  ratingColor: null,
+  groupJoinedAt: "2026-01-01T00:00:00.000Z",
+  memberSince: "2025-01-01T00:00:00.000Z",
+  challengeId: "c1",
+  challengeName: "Challenge 1",
+  challengeStatus: "COMPLETED",
+  challengeType: "Challenge",
+  challengeTrack: "Development",
+  challengeEndDate: "2026-02-01T00:00:00.000Z",
+  isCampusChallenge: true,
+  isPublicChallenge: false,
+  registeredAt: "2026-01-05T00:00:00.000Z",
+  registered: true,
+  submitted: false,
+  passedReview: false,
+  submittedDate: null,
+  score: null,
+  won: false,
+  placement: null,
+  ...overrides,
+});
+
+describe("TopcoderReportsService.getCampusLeaderboard", () => {
+  let service: TopcoderReportsService;
+  let groupRows: Row[];
+  let leaderboardRows: Row[];
+
+  beforeEach(() => {
+    groupRows = [
+      {
+        groupId: "group-1",
+        groupName: "MECW",
+        groupOldId: null,
+        privateGroup: false,
+        callerIsMember: false,
+      },
+    ];
+    leaderboardRows = [];
+
+    const db = {
+      query: jest.fn((query: string) => {
+        if (query === GROUP_QUERY) {
+          return groupRows;
+        }
+
+        if (query === LEADERBOARD_QUERY) {
+          return leaderboardRows;
+        }
+
+        throw new Error(`Unexpected query: ${query}`);
+      }),
+    };
+
+    service = new TopcoderReportsService(
+      db as unknown as DbService,
+      {
+        load: jest.fn((query: string) => query),
+      } as unknown as SqlLoaderService,
+      {
+        get: jest.fn((_key: string, defaultValue?: string) => defaultValue),
+      } as unknown as ConfigService,
+    );
+  });
+
+  it("throws when the group does not exist", async () => {
+    groupRows = [];
+
+    await expect(
+      service.getCampusLeaderboard({ groupName: "nope" }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("rejects non-members without report access for private groups", async () => {
+    groupRows = [
+      {
+        groupId: "group-1",
+        groupName: "MECW",
+        groupOldId: null,
+        privateGroup: true,
+        callerIsMember: false,
+      },
+    ];
+
+    await expect(
+      service.getCampusLeaderboard(
+        { groupName: "mecw" },
+        { userId: 999, hasReportAccess: false },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("allows group members and report readers to read private group leaderboards", async () => {
+    groupRows = [
+      {
+        groupId: "group-1",
+        groupName: "MECW",
+        groupOldId: null,
+        privateGroup: true,
+        callerIsMember: true,
+      },
+    ];
+    leaderboardRows = [participationRow()];
+
+    await expect(
+      service.getCampusLeaderboard({ groupName: "mecw" }, { userId: 1 }),
+    ).resolves.toMatchObject({ group: { id: "group-1", name: "MECW" } });
+  });
+
+  it("includes members with no activity and counts one submission per challenge", async () => {
+    leaderboardRows = [
+      // Two submission rows collapse to a single submitted challenge in SQL, so
+      // the service receives one row per member per challenge.
+      participationRow({
+        challengeId: "c1",
+        submitted: true,
+        passedReview: true,
+        won: true,
+        placement: 1,
+      }),
+      participationRow({ challengeId: "c2", submitted: true }),
+      participationRow({ challengeId: "c3" }),
+      participationRow({
+        userId: "2",
+        handle: "member2",
+        challengeId: null,
+        challengeName: null,
+        registered: null,
+        submitted: null,
+        passedReview: null,
+        won: null,
+        groupJoinedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = await service.getCampusLeaderboard({ groupName: "mecw" });
+
+    expect(result.summary).toEqual({
+      totalMembers: 2,
+      membersRegistered: 1,
+      membersSubmitted: 1,
+    });
+    expect(result.members).toHaveLength(2);
+    expect(result.members[0]).toMatchObject({
+      rank: 1,
+      handle: "member1",
+      registrations: 3,
+      submissions: 2,
+      passingSubmissions: 1,
+      wins: 1,
+      hasActivity: true,
+    });
+    expect(result.members[0].challenges).toHaveLength(3);
+    expect(result.members[1]).toMatchObject({
+      rank: 2,
+      handle: "member2",
+      registrations: 0,
+      submissions: 0,
+      passingSubmissions: 0,
+      wins: 0,
+      hasActivity: false,
+      challenges: [],
+    });
+  });
+
+  it("ranks by wins, then passing submissions, then registrations, then signup time", async () => {
+    leaderboardRows = [
+      // One win, fewest registrations -> first.
+      participationRow({
+        userId: "1",
+        handle: "winner",
+        challengeId: "c1",
+        submitted: true,
+        passedReview: true,
+        won: true,
+        placement: 1,
+      }),
+      // No wins but a passing submission -> second.
+      participationRow({
+        userId: "2",
+        handle: "passer",
+        challengeId: "c1",
+        submitted: true,
+        passedReview: true,
+      }),
+      participationRow({ userId: "2", handle: "passer", challengeId: "c2" }),
+      // No wins, no passing submissions, two registrations -> third.
+      participationRow({ userId: "3", handle: "regular", challengeId: "c1" }),
+      participationRow({ userId: "3", handle: "regular", challengeId: "c2" }),
+      // Same activity as "later" but signed up earlier -> fourth.
+      participationRow({
+        userId: "4",
+        handle: "earlier",
+        challengeId: "c1",
+        groupJoinedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      participationRow({
+        userId: "5",
+        handle: "later",
+        challengeId: "c1",
+        groupJoinedAt: "2026-06-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = await service.getCampusLeaderboard({ groupName: "mecw" });
+
+    expect(
+      result.members.map((member) => [member.handle, member.rank]),
+    ).toEqual([
+      ["winner", 1],
+      ["passer", 2],
+      ["regular", 3],
+      ["earlier", 4],
+      ["later", 5],
+    ]);
+  });
+
+  it("shares a rank between members whose ranking criteria are identical", async () => {
+    leaderboardRows = [
+      participationRow({
+        userId: "1",
+        handle: "aaa",
+        challengeId: "c1",
+        groupJoinedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      participationRow({
+        userId: "2",
+        handle: "bbb",
+        challengeId: "c1",
+        groupJoinedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ];
+
+    const result = await service.getCampusLeaderboard({ groupName: "mecw" });
+
+    expect(result.members.map((member) => member.rank)).toEqual([1, 1]);
+  });
+
+  it("filters counts and participation history by challenge visibility", async () => {
+    leaderboardRows = [
+      participationRow({
+        challengeId: "campus-1",
+        isCampusChallenge: true,
+        isPublicChallenge: false,
+        submitted: true,
+        passedReview: true,
+        won: true,
+      }),
+      participationRow({
+        challengeId: "public-1",
+        isCampusChallenge: false,
+        isPublicChallenge: true,
+        submitted: true,
+      }),
+    ];
+
+    const campusOnly = await service.getCampusLeaderboard({
+      groupName: "mecw",
+      challengeFilter: CampusChallengeFilter.Campus,
+    });
+    expect(campusOnly.members[0]).toMatchObject({
+      registrations: 1,
+      submissions: 1,
+      passingSubmissions: 1,
+      wins: 1,
+    });
+    expect(
+      campusOnly.members[0].challenges.map((entry) => entry.challengeId),
+    ).toEqual(["campus-1"]);
+
+    const publicOnly = await service.getCampusLeaderboard({
+      groupName: "mecw",
+      challengeFilter: CampusChallengeFilter.Public,
+    });
+    expect(publicOnly.members[0]).toMatchObject({
+      registrations: 1,
+      submissions: 1,
+      passingSubmissions: 0,
+      wins: 0,
+    });
+    expect(
+      publicOnly.members[0].challenges.map((entry) => entry.challengeId),
+    ).toEqual(["public-1"]);
+
+    // The summary tiles always describe activity across every challenge.
+    expect(publicOnly.summary).toEqual({
+      totalMembers: 1,
+      membersRegistered: 1,
+      membersSubmitted: 1,
+    });
+  });
+});

--- a/src/reports/topcoder/dto/campus-leaderboard.dto.spec.ts
+++ b/src/reports/topcoder/dto/campus-leaderboard.dto.spec.ts
@@ -1,0 +1,40 @@
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import {
+  CampusChallengeFilter,
+  CampusLeaderboardQueryDto,
+} from "./campus-leaderboard.dto";
+
+const toDto = (query: Record<string, unknown>) =>
+  plainToInstance(CampusLeaderboardQueryDto, query);
+
+describe("CampusLeaderboardQueryDto", () => {
+  it("trims the group name and normalizes the challenge filter", async () => {
+    const dto = toDto({ groupName: "  mecw  ", challengeFilter: " Campus " });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+    expect(dto.groupName).toBe("mecw");
+    expect(dto.challengeFilter).toBe(CampusChallengeFilter.Campus);
+  });
+
+  it("allows the challenge filter to be omitted", async () => {
+    const dto = toDto({ groupName: "mecw" });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+    expect(dto.challengeFilter).toBeUndefined();
+  });
+
+  it("requires a group name", async () => {
+    const errors = await validate(toDto({ groupName: "   " }));
+
+    expect(errors.map((error) => error.property)).toContain("groupName");
+  });
+
+  it("rejects unknown challenge filters", async () => {
+    const errors = await validate(
+      toDto({ groupName: "mecw", challengeFilter: "private" }),
+    );
+
+    expect(errors.map((error) => error.property)).toContain("challengeFilter");
+  });
+});

--- a/src/reports/topcoder/dto/campus-leaderboard.dto.ts
+++ b/src/reports/topcoder/dto/campus-leaderboard.dto.ts
@@ -1,0 +1,22 @@
+import { Transform } from "class-transformer";
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+export enum CampusChallengeFilter {
+  All = "all",
+  Public = "public",
+  Campus = "campus",
+}
+
+export class CampusLeaderboardQueryDto {
+  @Transform(({ value }) => (typeof value === "string" ? value.trim() : value))
+  @IsString()
+  @IsNotEmpty()
+  groupName!: string;
+
+  @Transform(({ value }) =>
+    typeof value === "string" ? value.trim().toLowerCase() : value,
+  )
+  @IsOptional()
+  @IsEnum(CampusChallengeFilter)
+  challengeFilter?: CampusChallengeFilter;
+}

--- a/src/reports/topcoder/topcoder-reports.controller.ts
+++ b/src/reports/topcoder/topcoder-reports.controller.ts
@@ -3,12 +3,14 @@ import {
   Get,
   Param,
   Query,
+  Req,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { TopcoderReportsService } from "./topcoder-reports.service";
 import { ChallengeSubmitterDataQueryDto } from "./dto/challenge-submitter-data.dto";
+import { CampusLeaderboardQueryDto } from "./dto/campus-leaderboard.dto";
 import { LeaderboardGenericQueryDto } from "./dto/leaderboard-generic.dto";
 import { LeaderboardMmQueryDto } from "./dto/leaderboard-mm.dto";
 import { RegistrantCountriesQueryDto } from "./dto/registrant-countries.dto";
@@ -19,6 +21,7 @@ import { TopcoderReportsGuard } from "../../auth/guards/topcoder-reports.guard";
 import { CsvResponseInterceptor } from "../../common/interceptors/csv-response.interceptor";
 import { Scopes as RequiredScopes } from "../../auth/decorators/scopes.decorator";
 import { Scopes as AppScopes } from "../../app-constants";
+import { AuthUserLike, hasAccessToScopes } from "../../auth/permissions.util";
 
 @ApiTags("Topcoder Reports")
 @ApiBearerAuth()
@@ -63,6 +66,30 @@ export class TopcoderReportsController {
   @ApiOperation({ summary: "Generic leaderboard report data" })
   getLeaderboardGeneric(@Query() query: LeaderboardGenericQueryDto) {
     return this.reports.getLeaderboardGeneric(query);
+  }
+
+  @Get("/topcoder/leaderboard/campus")
+  // Campus members read their own program leaderboard, so no report scope is
+  // required; access to private groups is enforced in the service instead.
+  @RequiredScopes()
+  @ApiOperation({
+    summary:
+      "Campus program leaderboard for every member of the requested group, including members with no challenge activity",
+  })
+  getCampusLeaderboard(
+    @Query() query: CampusLeaderboardQueryDto,
+    @Req() request: { authUser?: AuthUserLike & { userId?: string | number } },
+  ) {
+    const authUser = request.authUser;
+
+    return this.reports.getCampusLeaderboard(query, {
+      userId: authUser?.userId,
+      hasReportAccess: hasAccessToScopes(authUser, [
+        AppScopes.AllReports,
+        AppScopes.TopcoderReports,
+        AppScopes.TopcoderLeaderboardReports,
+      ]),
+    });
   }
 
   @Get("/topcoder/leaderboard/mm")

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -1,6 +1,12 @@
-import { Injectable, NotFoundException, OnModuleDestroy } from "@nestjs/common";
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  OnModuleDestroy,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { DbService } from "../../db/db.service";
+import { CampusChallengeFilter } from "./dto/campus-leaderboard.dto";
 import { SqlLoaderService } from "../../common/sql-loader.service";
 import { alpha3ToCountryName } from "../../common/country.util";
 import { Pool } from "pg";
@@ -122,6 +128,80 @@ type LeaderboardGenericRow = {
   challengeStatus: string;
   isAiOnlyChallenge: boolean;
   userSubmissionsCount: number;
+};
+
+type CampusGroupRow = {
+  groupId: string;
+  groupName: string;
+  groupOldId: string | null;
+  privateGroup: boolean;
+  callerIsMember: boolean;
+};
+
+type CampusLeaderboardRow = {
+  userId: string;
+  handle: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  photoURL: string | null;
+  rating: string | number | null;
+  ratingColor: string | null;
+  groupJoinedAt: Date | string | null;
+  memberSince: Date | string | null;
+  challengeId: string | null;
+  challengeName: string | null;
+  challengeStatus: string | null;
+  challengeType: string | null;
+  challengeTrack: string | null;
+  challengeEndDate: Date | string | null;
+  isCampusChallenge: boolean | null;
+  isPublicChallenge: boolean | null;
+  registeredAt: Date | string | null;
+  registered: boolean | null;
+  submitted: boolean | null;
+  passedReview: boolean | null;
+  submittedDate: Date | string | null;
+  score: string | number | null;
+  won: boolean | null;
+  placement: number | null;
+};
+
+type CampusParticipationEntry = {
+  challengeId: string;
+  challengeName: string | null;
+  challengeStatus: string | null;
+  challengeType: string | null;
+  challengeTrack: string | null;
+  challengeEndDate: string | null;
+  isCampusChallenge: boolean;
+  isPublicChallenge: boolean;
+  registered: boolean;
+  registeredAt: string | null;
+  submitted: boolean;
+  submittedDate: string | null;
+  passedReview: boolean;
+  score: number | null;
+  won: boolean;
+  placement: number | null;
+};
+
+type CampusLeaderboardEntry = {
+  rank: number;
+  userId: string;
+  handle: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  photoURL: string | null;
+  rating: number | null;
+  ratingColor: string | null;
+  signupDate: string | null;
+  memberSince: string | null;
+  registrations: number;
+  submissions: number;
+  passingSubmissions: number;
+  wins: number;
+  hasActivity: boolean;
+  challenges: CampusParticipationEntry[];
 };
 
 type LeaderboardMmRow = {
@@ -1172,6 +1252,216 @@ export class TopcoderReportsService implements OnModuleDestroy {
         : placementData,
       challenges,
     };
+  }
+
+  /**
+   * Campus program leaderboard for every member of the requested group.
+   *
+   * Members with no challenge activity are included (ranked last). Submissions and
+   * passing submissions are counted at most once per member per challenge.
+   *
+   * @param filters Group name and challenge visibility filter.
+   * @param caller Caller identity used to authorize access to private groups.
+   */
+  async getCampusLeaderboard(
+    filters: {
+      groupName: string;
+      challengeFilter?: CampusChallengeFilter;
+    },
+    caller: {
+      userId?: string | number | null;
+      hasReportAccess?: boolean;
+    } = {},
+  ) {
+    const groupName = filters.groupName?.trim() ?? "";
+    const callerId =
+      caller.userId === null || caller.userId === undefined
+        ? null
+        : String(caller.userId).trim() || null;
+
+    const groupQuery = this.sql.load(
+      "reports/topcoder/campus-leaderboard-group.sql",
+    );
+    const [group] = await this.db.query<CampusGroupRow>(groupQuery, [
+      groupName,
+      callerId,
+    ]);
+
+    if (!group) {
+      throw new NotFoundException(`Group "${groupName}" was not found.`);
+    }
+
+    if (
+      group.privateGroup &&
+      !caller.hasReportAccess &&
+      !group.callerIsMember
+    ) {
+      throw new ForbiddenException(
+        "You do not have the required permissions to access this leaderboard.",
+      );
+    }
+
+    const challengeFilter =
+      filters.challengeFilter ?? CampusChallengeFilter.All;
+    const query = this.sql.load("reports/topcoder/campus-leaderboard.sql");
+    const rows = await this.db.query<CampusLeaderboardRow>(query, [groupName]);
+
+    const membersById = new Map<string, CampusLeaderboardEntry>();
+    // Unfiltered participation, kept aside so the summary tiles can report
+    // activity across every challenge regardless of the visibility filter.
+    const allChallengesByUser = new Map<string, CampusParticipationEntry[]>();
+
+    rows.forEach((row) => {
+      const userId = String(row.userId);
+      let member = membersById.get(userId);
+
+      if (!member) {
+        member = {
+          rank: 0,
+          userId,
+          handle: this.toOptionalString(row.handle),
+          firstName: this.toOptionalString(row.firstName),
+          lastName: this.toOptionalString(row.lastName),
+          photoURL: this.toOptionalString(row.photoURL),
+          rating: this.toNullableNumber(row.rating),
+          ratingColor: this.toOptionalString(row.ratingColor),
+          signupDate:
+            this.normalizeDate(row.groupJoinedAt) ??
+            this.normalizeDate(row.memberSince),
+          memberSince: this.normalizeDate(row.memberSince),
+          registrations: 0,
+          submissions: 0,
+          passingSubmissions: 0,
+          wins: 0,
+          hasActivity: false,
+          challenges: [],
+        };
+        membersById.set(userId, member);
+        allChallengesByUser.set(userId, []);
+      }
+
+      if (!row.challengeId) {
+        return;
+      }
+
+      allChallengesByUser.get(userId)!.push({
+        challengeId: row.challengeId,
+        challengeName: this.toOptionalString(row.challengeName),
+        challengeStatus: this.toOptionalString(row.challengeStatus),
+        challengeType: this.toOptionalString(row.challengeType),
+        challengeTrack: this.toOptionalString(row.challengeTrack),
+        challengeEndDate: this.normalizeDate(row.challengeEndDate),
+        isCampusChallenge: row.isCampusChallenge === true,
+        isPublicChallenge: row.isPublicChallenge === true,
+        registered: row.registered === true,
+        registeredAt: this.normalizeDate(row.registeredAt),
+        submitted: row.submitted === true,
+        submittedDate: this.normalizeDate(row.submittedDate),
+        passedReview: row.passedReview === true,
+        score: this.toNullableNumber(row.score),
+        won: row.won === true,
+        placement: row.placement ?? null,
+      });
+    });
+
+    const members = Array.from(membersById.values());
+
+    const summary = {
+      totalMembers: members.length,
+      membersRegistered: members.filter((member) =>
+        allChallengesByUser
+          .get(member.userId)!
+          .some((entry) => entry.registered),
+      ).length,
+      membersSubmitted: members.filter((member) =>
+        allChallengesByUser
+          .get(member.userId)!
+          .some((entry) => entry.submitted),
+      ).length,
+    };
+
+    members.forEach((member) => {
+      const challenges = allChallengesByUser
+        .get(member.userId)!
+        .filter((entry) =>
+          this.matchesCampusChallengeFilter(entry, challengeFilter),
+        );
+
+      member.challenges = challenges;
+      member.hasActivity = challenges.length > 0;
+      member.registrations = challenges.filter(
+        (entry) => entry.registered,
+      ).length;
+      member.submissions = challenges.filter((entry) => entry.submitted).length;
+      member.passingSubmissions = challenges.filter(
+        (entry) => entry.submitted && entry.passedReview,
+      ).length;
+      member.wins = challenges.filter((entry) => entry.won).length;
+    });
+
+    const sortKeys = (member: CampusLeaderboardEntry) => [
+      -member.wins,
+      -member.passingSubmissions,
+      -member.registrations,
+      member.signupDate
+        ? Date.parse(member.signupDate)
+        : Number.MAX_SAFE_INTEGER,
+    ];
+
+    const sortedMembers = members.sort((left, right) => {
+      const leftKeys = sortKeys(left);
+      const rightKeys = sortKeys(right);
+
+      for (let index = 0; index < leftKeys.length; index += 1) {
+        if (leftKeys[index] !== rightKeys[index]) {
+          return leftKeys[index] - rightKeys[index];
+        }
+      }
+
+      return (left.handle ?? "").localeCompare(right.handle ?? "");
+    });
+
+    let previousKeys: number[] | null = null;
+    let previousRank = 0;
+
+    const leaderboard = sortedMembers.map((member, index) => {
+      const keys = sortKeys(member);
+      const tiedWithPrevious =
+        !!previousKeys && previousKeys.every((key, i) => key === keys[i]);
+      const rank = tiedWithPrevious ? previousRank : index + 1;
+
+      previousKeys = keys;
+      previousRank = rank;
+
+      return { ...member, rank };
+    });
+
+    return {
+      group: {
+        id: group.groupId,
+        name: group.groupName,
+        oldId: group.groupOldId ?? null,
+        privateGroup: group.privateGroup === true,
+      },
+      challengeFilter,
+      summary,
+      members: leaderboard,
+    };
+  }
+
+  private matchesCampusChallengeFilter(
+    entry: CampusParticipationEntry,
+    challengeFilter: CampusChallengeFilter,
+  ): boolean {
+    if (challengeFilter === CampusChallengeFilter.Public) {
+      return entry.isPublicChallenge;
+    }
+
+    if (challengeFilter === CampusChallengeFilter.Campus) {
+      return entry.isCampusChallenge;
+    }
+
+    return true;
   }
 
   private calculateWriterTesterBonuses(

--- a/src/reports/topcoder/topcoder-reports.service.ts
+++ b/src/reports/topcoder/topcoder-reports.service.ts
@@ -1403,7 +1403,7 @@ export class TopcoderReportsService implements OnModuleDestroy {
       -member.wins,
       -member.passingSubmissions,
       -member.registrations,
-      member.signupDate
+      member.signupDate && Number.isFinite(Date.parse(member.signupDate))
         ? Date.parse(member.signupDate)
         : Number.MAX_SAFE_INTEGER,
     ];


### PR DESCRIPTION
This pull request introduces a new "Campus Leaderboard" report for Topcoder groups, including all group members (even those without challenge activity) and supporting filtering by challenge type. It adds SQL queries, a DTO for query validation, a new controller route, service logic with comprehensive tests, and updates to the authorization guard to allow access for authenticated users (with private group access enforced in the service).

**Campus Leaderboard Feature**

* Added `campus-leaderboard.sql` and `campus-leaderboard-group.sql` to generate a leaderboard for all members of a specified group, with support for filtering by group name/id/legacy id and including members with no activity. [[1]](diffhunk://#diff-5d055a032b04cd6d7f82e55fcb3f8454a5fa8faca05fdf4530635a5b6d14f956R1-R248) [[2]](diffhunk://#diff-0b1257e55afade66e78c7ba408e24c29ace8cabdc823247d8f5e71ceb1244ebaR1-R48)
* Introduced `CampusLeaderboardQueryDto` and `CampusChallengeFilter` to validate and normalize incoming query parameters, with unit tests for validation logic. [[1]](diffhunk://#diff-a3388cd091cf9fd9153726cfc471129ece3442cd7d5f71c10875963ca6a35dccR1-R22) [[2]](diffhunk://#diff-d1d4ac618b6b7477807176f8e486ed19cc7267be95cd69929ca22811dab36220R1-R40)
* Implemented `getCampusLeaderboard` in `TopcoderReportsService` with tests covering group existence, private group access, ranking logic, and challenge filtering.
* Added `/topcoder/leaderboard/campus` route to `TopcoderReportsController`, accepting the new DTO and enforcing access rules: any authenticated user can access public groups, while private group access is restricted to members or report readers. [[1]](diffhunk://#diff-e658b642cbc0cb5d6930c3dd241737dd8b8fd98279b4a5d71c543e4d44d60ef3R6-R13) [[2]](diffhunk://#diff-e658b642cbc0cb5d6930c3dd241737dd8b8fd98279b4a5d71c543e4d44d60ef3R24) [[3]](diffhunk://#diff-e658b642cbc0cb5d6930c3dd241737dd8b8fd98279b4a5d71c543e4d44d60ef3R71-R94)

**Authorization Updates**

* Updated `TopcoderReportsGuard` and its tests to allow any authenticated user to access the campus leaderboard route, with group privacy enforced in the service layer. [[1]](diffhunk://#diff-0b7c437ae27a1038960814da618e4f430327cc78f9163b112eb4c7850219183aR54-R62) [[2]](diffhunk://#diff-0b7c437ae27a1038960814da618e4f430327cc78f9163b112eb4c7850219183aR121-R126)