### PR TITLE
PM-5867 - exclude F2F, Task from general statistics

### DIFF
--- a/sql/reports/statistics/general/country-member-details.sql
+++ b/sql/reports/statistics/general/country-member-details.sql
@@ -78,6 +78,8 @@ stats_wins AS (
    AND history."typeId" = stats."typeId"
   LEFT JOIN challenges."ChallengeTrack" track
     ON track.id::text = stats."trackId"
+  LEFT JOIN challenges."ChallengeType" ct
+    ON ct.id::text = stats."typeId"
   WHERE stats."isPrivate" = false
     AND (
       UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
@@ -87,6 +89,7 @@ stats_wins AS (
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
     )
+    AND (ct.name IS NULL OR NOT ct.name = ANY($1))
   GROUP BY stats."userId"
 ),
 winner_counts AS (

--- a/sql/reports/statistics/general/first-place-by-country.sql
+++ b/sql/reports/statistics/general/first-place-by-country.sql
@@ -19,6 +19,8 @@ member_wins AS (
    AND history."typeId" = stats."typeId"
   LEFT JOIN challenges."ChallengeTrack" track
     ON track.id::text = stats."trackId"
+  LEFT JOIN challenges."ChallengeType" ct
+    ON ct.id::text = stats."typeId"
   WHERE stats."isPrivate" = false
     AND (
       UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
@@ -28,6 +30,7 @@ member_wins AS (
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
     )
+    AND (ct.name IS NULL OR NOT ct.name = ANY($1))
   GROUP BY stats."userId"
 ),
 winners_country AS (

--- a/sql/reports/statistics/general/top-winners-by-country.sql
+++ b/sql/reports/statistics/general/top-winners-by-country.sql
@@ -19,6 +19,8 @@ stats_wins AS (
    AND history."typeId" = stats."typeId"
   LEFT JOIN challenges."ChallengeTrack" track
     ON track.id::text = stats."trackId"
+  LEFT JOIN challenges."ChallengeType" ct
+    ON ct.id::text = stats."typeId"
   WHERE stats."isPrivate" = false
     AND (
       UPPER(COALESCE(track.name, stats."trackId")) LIKE '%DEVELOP%'
@@ -28,6 +30,7 @@ stats_wins AS (
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%QUALITY%ASSURANCE%'
       OR UPPER(COALESCE(track.name, stats."trackId")) LIKE '%COPILOT%'
     )
+    AND (ct.name IS NULL OR NOT ct.name = ANY($1))
   GROUP BY stats."userId"
 ),
 winner_profiles AS (

--- a/src/statistics/general-statistics.service.spec.ts
+++ b/src/statistics/general-statistics.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from "@nestjs/config";
 import { DbService } from "../db/db.service";
 import { SqlLoaderService } from "../common/sql-loader.service";
 import { GeneralStatisticsService } from "./general-statistics.service";
@@ -9,9 +10,13 @@ describe("GeneralStatisticsService", () => {
   const sql = {
     load: jest.fn().mockReturnValue("SELECT tooltip data"),
   };
+  const config = {
+    get: jest.fn().mockReturnValue('["Task","First2Finish"]'),
+  };
   const service = new GeneralStatisticsService(
     db as unknown as DbService,
     sql as unknown as SqlLoaderService,
+    config as unknown as ConfigService,
   );
 
   beforeEach(() => {
@@ -65,6 +70,10 @@ describe("GeneralStatisticsService", () => {
     expect(sql.load).toHaveBeenCalledWith(
       "reports/statistics/general/top-winners-by-country.sql",
     );
+    expect(db.query).toHaveBeenCalledWith(
+      "SELECT tooltip data",
+      [["Task", "First2Finish"]],
+    );
   });
 
   it("uses safe defaults when winner details are absent", async () => {
@@ -85,6 +94,10 @@ describe("GeneralStatisticsService", () => {
         topWinners: [],
       },
     ]);
+    expect(db.query).toHaveBeenCalledWith(
+      "SELECT tooltip data",
+      [["Task", "First2Finish"]],
+    );
   });
 
   it("normalizes country member, skill, and top-member details", async () => {
@@ -177,6 +190,10 @@ describe("GeneralStatisticsService", () => {
     ]);
     expect(sql.load).toHaveBeenCalledWith(
       "reports/statistics/general/country-member-details.sql",
+    );
+    expect(db.query).toHaveBeenCalledWith(
+      "SELECT tooltip data",
+      [["Task", "First2Finish"]],
     );
   });
 });

--- a/src/statistics/general-statistics.service.ts
+++ b/src/statistics/general-statistics.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { DbService } from "../db/db.service";
 import { SqlLoaderService } from "../common/sql-loader.service";
 import { alpha3ToCountryName } from "../common/country.util";
@@ -28,10 +29,44 @@ type CountryMemberDetailRow = {
 
 @Injectable()
 export class GeneralStatisticsService {
+  private readonly excludedChallengeTypes: string[];
+
   constructor(
     private readonly db: DbService,
     private readonly sql: SqlLoaderService,
-  ) {}
+    private readonly config: ConfigService,
+  ) {
+    this.excludedChallengeTypes = this.parseExcludedChallengeTypes();
+  }
+
+  private parseExcludedChallengeTypes(): string[] {
+    const raw = this.config
+      .get<string>(
+        "REPORTS_EXCLUDED_CHALLENGE_TYPES",
+        '["Task","First2Finish"]',
+      )
+      .trim();
+
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter((item) => typeof item === "string" && item.trim())
+          .map((item) => item.trim());
+      }
+    } catch {
+      // ignore JSON parse failure and fall back to comma-separated values
+    }
+
+    return raw
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
 
   async getMemberCount() {
     const q = this.sql.load("reports/statistics/general/member-count.sql");
@@ -81,7 +116,9 @@ export class GeneralStatisticsService {
     const q = this.sql.load(
       "reports/statistics/general/country-member-details.sql",
     );
-    const rows = await this.db.query<CountryMemberDetailRow>(q);
+    const rows = await this.db.query<CountryMemberDetailRow>(q, [
+      this.excludedChallengeTypes,
+    ]);
     const countries = new Map<
       string,
       {
@@ -208,7 +245,7 @@ export class GeneralStatisticsService {
       country_code: string | null;
       "challenge_stats.count": number | string | null;
       rank: number | string | null;
-    }>(q);
+    }>(q, [this.excludedChallengeTypes]);
     return rows.map((row) => {
       const countryName =
         alpha3ToCountryName(row.country_code) ?? row.country_code ?? "";
@@ -235,7 +272,7 @@ export class GeneralStatisticsService {
         photoURL?: string | null;
         wins?: number | string | null;
       }> | null;
-    }>(q);
+    }>(q, [this.excludedChallengeTypes]);
 
     return rows.map((row) => {
       const countryName =


### PR DESCRIPTION
This pull request updates how excluded challenge types are handled in general statistics reports. It centralizes the logic for excluding certain challenge types (like "Task" and "First2Finish") by reading from a configuration value, and ensures all relevant SQL queries consistently filter out these types. The tests are also updated to verify that the exclusion logic is applied correctly.

**Enhancements to challenge type exclusion:**

* The `GeneralStatisticsService` now reads excluded challenge types from the `REPORTS_EXCLUDED_CHALLENGE_TYPES` config value, with robust parsing for both JSON and comma-separated formats. This makes it easier to update which challenge types are excluded without changing code. [[1]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affR32-R69) [[2]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affR32-R69)
* All SQL queries for member and winner statistics (`country-member-details.sql`, `first-place-by-country.sql`, `top-winners-by-country.sql`) now join with the `ChallengeType` table and filter out challenges whose type matches the excluded list, ensuring consistent application of the exclusion logic. [[1]](diffhunk://#diff-cbae4d7e71168d9363eb912c48a49a512902c748fe471edee88dcbe7b5feb7ddR81-R82) [[2]](diffhunk://#diff-cbae4d7e71168d9363eb912c48a49a512902c748fe471edee88dcbe7b5feb7ddR92) [[3]](diffhunk://#diff-6eaa2503504cf7b64f645720de3cc9aa878f786f595fb4512779f4b604a698ccR22-R23) [[4]](diffhunk://#diff-6eaa2503504cf7b64f645720de3cc9aa878f786f595fb4512779f4b604a698ccR33) [[5]](diffhunk://#diff-daaa62d6ca59208d371158720ae906641aeb5dcb931af20053372d229287db54R22-R23) [[6]](diffhunk://#diff-daaa62d6ca59208d371158720ae906641aeb5dcb931af20053372d229287db54R33)
* The service methods that query for country member details and winner statistics now pass the excluded challenge types as parameters to the SQL queries. [[1]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affL84-R121) [[2]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affL211-R248) [[3]](diffhunk://#diff-ed378e1a715628b7dc398a08bfd17849ea3bfec81445bbbd0a80fa2a0a9e0affL238-R275)

**Testing improvements:**

* The service tests are updated to mock the config value and verify that the excluded challenge types are passed as parameters to the SQL queries, ensuring the new logic is properly exercised. [[1]](diffhunk://#diff-fb1b6ebfbe8087bdd2783cc5866c68fff8cc053957bdfc051600a3b8f675fc1cR1) [[2]](diffhunk://#diff-fb1b6ebfbe8087bdd2783cc5866c68fff8cc053957bdfc051600a3b8f675fc1cR13-R19) [[3]](diffhunk://#diff-fb1b6ebfbe8087bdd2783cc5866c68fff8cc053957bdfc051600a3b8f675fc1cR73-R76) [[4]](diffhunk://#diff-fb1b6ebfbe8087bdd2783cc5866c68fff8cc053957bdfc051600a3b8f675fc1cR97-R100) [[5]](diffhunk://#diff-fb1b6ebfbe8087bdd2783cc5866c68fff8cc053957bdfc051600a3b8f675fc1cR194-R197)

These changes make the exclusion of certain challenge types more maintainable and consistent across all general statistics reports.