### PR TITLE
PM-5370 - return winner placement

### DIFF
--- a/sql/reports/topcoder/campus-leaderboard.sql
+++ b/sql/reports/topcoder/campus-leaderboard.sql
@@ -144,7 +144,7 @@ member_submissions AS (
   FROM scored_submissions AS ss
   GROUP BY ss.member_id, ss.challenge_id
 ),
-member_wins AS (
+member_placements AS (
   SELECT
     cw."userId"::text AS member_id,
     cw."challengeId" AS challenge_id,
@@ -152,8 +152,7 @@ member_wins AS (
   FROM challenges."ChallengeWinner" AS cw
   JOIN group_members AS gm
     ON gm.member_id = cw."userId"::text
-  WHERE cw.placement = 1
-    AND cw.type = 'PLACEMENT'
+  WHERE cw.type = 'PLACEMENT'
   GROUP BY cw."userId", cw."challengeId"
 ),
 participation AS (
@@ -161,7 +160,7 @@ participation AS (
   UNION
   SELECT member_id, challenge_id FROM member_submissions
   UNION
-  SELECT member_id, challenge_id FROM member_wins
+  SELECT member_id, challenge_id FROM member_placements
 ),
 member_participation AS (
   SELECT
@@ -180,7 +179,7 @@ member_participation AS (
     COALESCE(sub.has_passing_submission, FALSE) AS passed_review,
     sub.first_submitted_date,
     sub.best_score,
-    (win.member_id IS NOT NULL) AS won,
+    (win.member_id IS NOT NULL AND win.placement = 1) AS won,
     win.placement
   FROM participation AS p
   CROSS JOIN group_identifiers AS gi
@@ -196,7 +195,7 @@ member_participation AS (
   LEFT JOIN member_submissions AS sub
     ON sub.member_id = p.member_id
    AND sub.challenge_id = p.challenge_id
-  LEFT JOIN member_wins AS win
+  LEFT JOIN member_placements AS win
     ON win.member_id = p.member_id
    AND win.challenge_id = p.challenge_id
 ),

--- a/src/reports/topcoder/campus-leaderboard.service.spec.ts
+++ b/src/reports/topcoder/campus-leaderboard.service.spec.ts
@@ -181,6 +181,35 @@ describe("TopcoderReportsService.getCampusLeaderboard", () => {
     });
   });
 
+  it("returns non-winning placements such as 2nd and 3rd place", async () => {
+    leaderboardRows = [
+      participationRow({
+        challengeId: "c1",
+        submitted: true,
+        passedReview: true,
+        won: false,
+        placement: 2,
+      }),
+      participationRow({
+        challengeId: "c2",
+        submitted: true,
+        passedReview: true,
+        won: false,
+        placement: 3,
+      }),
+    ];
+
+    const result = await service.getCampusLeaderboard({ groupName: "mecw" });
+
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0].challenges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ placement: 2 }),
+        expect.objectContaining({ placement: 3 }),
+      ]),
+    );
+  });
+
   it("ranks by wins, then passing submissions, then registrations, then signup time", async () => {
     leaderboardRows = [
       // One win, fewest registrations -> first.


### PR DESCRIPTION
This pull request updates the campus leaderboard report to track and display all placements (not just wins) for Topcoder challenges, and adds tests to ensure non-winning placements are correctly handled. The changes also clarify the definition of a "win" in the leaderboard logic.

**Leaderboard SQL logic updates:**

* The CTE previously named `member_wins` is renamed to `member_placements` and now includes all placements, not just first place. The logic for determining a "win" is updated to check for `placement = 1` instead of filtering at the SQL level.
* The `participation` CTE and all related joins are updated to use `member_placements` instead of `member_wins`, ensuring all placements are considered throughout the report. [[1]](diffhunk://#diff-5d055a032b04cd6d7f82e55fcb3f8454a5fa8faca05fdf4530635a5b6d14f956L147-R163) [[2]](diffhunk://#diff-5d055a032b04cd6d7f82e55fcb3f8454a5fa8faca05fdf4530635a5b6d14f956L199-R198)
* The `won` field in the leaderboard output is now computed as `win.member_id IS NOT NULL AND win.placement = 1`, so only first-place finishes are counted as wins, while other placements are still tracked.

**Test coverage improvements:**

* Added a test to verify that non-winning placements (such as 2nd and 3rd place) are returned and correctly represented in the leaderboard results.